### PR TITLE
GUI mapping and Ux Fixes

### DIFF
--- a/include/aon/drivetrain.hpp
+++ b/include/aon/drivetrain.hpp
@@ -40,6 +40,11 @@ class Drivetrain {
   }
   void setTheta(double theta) { this->pose.theta = theta; }
 
+  void resetPose(double x = 0.0, double y = 0.0, double theta = 0.0) {
+  this->odometry->resetCurrent(x, y, theta);
+  }
+
+
   bool isTurbo() { return this->turbo; }
   void setTurbo(bool turbo) { this->turbo = turbo; }
   void toggleTurbo() { this->turbo = !this->turbo; }

--- a/include/aon/tools/gui/GUIDE_GUI.md
+++ b/include/aon/tools/gui/GUIDE_GUI.md
@@ -2,13 +2,14 @@
 
 ## Overview
 
-The GUI system provides five main features:
+The GUI system provides six main features:
 
 1. **Registered Autons** — Register functions and select them from the Debug Menu
 2. **Auton Runner** — Execute autonomous routines on-demand during testing
 3. **Tunable Variables** — Live adjustment of parameters without rebuilding
 4. **Data Menu** — Live display of registered numeric values with reset controls
 5. **Live Graph** — Real-time visualization of X/Y data (e.g., odometry)
+6. **Field Mapper** — Real-time robot path trace on a top-down field view with arc measurement
 
 ---
 
@@ -22,6 +23,7 @@ The GUI system provides five main features:
 - [Tunable Variables](#tunable-variables)
 - [Data Menu](#data-menu)
 - [Live Graph](#live-graph)
+- [Field Mapper](#field-mapper)
 - [Complete Example](#complete-example)
 - [API Reference](#api-reference)
 - [Troubleshooting](#troubleshooting)
@@ -389,6 +391,11 @@ void initialize() {
     []() { return drivetrain.odom.getY(); }
   );
 
+  aon::gui->setMapDataProvider([]() -> aon::Pose {
+    return {drivetrain.getX(), drivetrain.getY(),
+            drivetrain.getTheta() * M_PI / 180.0};
+  });
+
   aon::gui.RegisterResetHandler("ResetOdom", []{
     drivetrain.odom.resetCurrent(0.0, 0.0, 0.0);
   });
@@ -449,6 +456,12 @@ Supported signatures: `int(*)()`, `void(*)()`, `std::function<int()>`, lambda.
 | Function | Description |
 |----------|-------------|
 | `aon::gui.SetGraphDataProviders(xFunc, yFunc)` | Set X and Y data provider callbacks |
+
+### Field Mapper
+
+| Function | Description |
+|----------|-------------|
+| `aon::gui->setMapDataProvider(poseFunc)` | Set a `std::function<Pose()>` callback; `Pose.theta` must be in **radians** |
 
 ### State Properties
 

--- a/include/aon/tools/gui/GUIDE_GUI.md
+++ b/include/aon/tools/gui/GUIDE_GUI.md
@@ -453,7 +453,7 @@ drivetrain.driveAngleOfArc(-12.5, 90.0);
 
 - Only active under `GuiDebug` (`TESTING_AUTONOMOUS true`). No-op on base `Gui`.
 - Call `setMapDataProvider()` **before** `aon::gui->initialize()`.
-- Buffer holds up to 1 000 points; once full, new points are dropped until **CLEAR** is pressed.
+- Buffer holds up to 600 points; once full, new points are dropped until **CLEAR** is pressed.
 - Arc results use `DRIVE_WIDTH` from `constants.hpp` for Inner/Out values, so they automatically reflect whichever robot is selected via `USING_BIG_ROBOT`.
 
 ---

--- a/include/aon/tools/gui/GUIDE_GUI.md
+++ b/include/aon/tools/gui/GUIDE_GUI.md
@@ -358,6 +358,106 @@ aon::gui.SetGraphDataProviders(
 
 ---
 
+## Field Mapper
+
+The Field Mapper (**Debug Menu → Field Mapper**) draws a top-down trace of the robot's path on a 6-tile VEX field. It also lets you measure arc geometry between any two points on the path so you can directly copy the values into `driveAngleOfArc()`.
+
+### API
+
+```cpp
+aon::gui->setMapDataProvider([]() -> aon::Pose {
+  return {drivetrain.getX(), drivetrain.getY(),
+          drivetrain.getTheta() * M_PI / 180.0};
+});
+```
+
+`Pose` fields:
+- `x` — robot X position in **inches**
+- `y` — robot Y position in **inches**
+- `theta` — robot heading in **radians**
+
+> `getTheta()` returns degrees — multiply by `M_PI / 180.0` before passing it.
+
+### How It Works
+
+1. `setMapDataProvider(callback)` stores the pose provider.
+2. While the Field Mapper screen is open, the pose is sampled periodically and appended to the path buffer (up to 1 000 points).
+3. The full path is drawn in **cyan**. The most recent position shows a heading arrow.
+4. **CLEAR** erases the recorded path and resets arc state.
+
+### Screen Layout
+
+```
+┌────────────────────────────────────────────────────────────┐
+│ [BACK]           FIELD MAPPER                    [CLEAR]   │
+├─────────────────────┬──────────────────────────────────────┤
+│                     │  X:  12.34"                          │
+│   6-tile field      │  Y:  -5.67"                          │
+│   (cyan path,       │  H:  90.0°                           │
+│    yellow arc seg,  │  D:  47.83"                          │
+│    green dot =      │ ────────────────────                 │
+│    arc start)       │  ARC:                                │
+│                     │  Radius: 12.50"  ΔHdg: 90°           │
+│                     │  ArcLen: 19.63"                      │
+│                     │  Chord:  17.68"                      │
+│                     │  Inner: 6.97"  Out: 18.03"           │
+├─────────────────────┼──────────────────────────────────────┤
+│                     │  [MARK S]         [MARK E]           │
+└─────────────────────┴──────────────────────────────────────┘
+```
+
+### Data Panel
+
+| Field | Description |
+|-------|-------------|
+| **X** | Current robot X in inches |
+| **Y** | Current robot Y in inches |
+| **H** | Current heading in degrees |
+| **D** | Total path distance traveled in inches |
+
+### Arc Measurement
+
+Use the two buttons at the bottom of the data panel:
+
+| Button | Color | Action |
+|--------|-------|--------|
+| **MARK S** | Dark green | Mark the current end of the path as the arc start; arc segment highlights yellow |
+| **MARK E** | Dark blue | Compute arc from marked start to current end |
+
+Once measured, the arc segment highlights in **yellow** (green dot marks the start) and the panel displays:
+
+| Field | Description | Use in code |
+|-------|-------------|-------------|
+| **Radius** | Robot-center arc radius in inches | First arg of `driveAngleOfArc(radius, angle)` |
+| **ΔHdg** | Total heading change in degrees (shown beside Radius) | Second arg of `driveAngleOfArc(radius, angle)` |
+| **ArcLen** | Cumulative path length along the arc in inches | — |
+| **Chord** | Straight-line distance start → end in inches | — |
+| **Inner** | Inner drive-wheel radius (`Radius − DRIVE_WIDTH/2`) | Reference only |
+| **Out** | Outer drive-wheel radius (`Radius + DRIVE_WIDTH/2`) | Reference only |
+
+### Using Arc Results in Autonomous
+
+```cpp
+// Field Mapper showed: Radius: 12.50", ΔHdg: 90°, turning right (clockwise)
+drivetrain.driveAngleOfArc(12.5, 90.0);   // positive radius = clockwise
+
+// Turning left (counter-clockwise): negate the radius
+drivetrain.driveAngleOfArc(-12.5, 90.0);
+```
+
+- **Radius** is already the robot-center radius — pass it directly, no adjustment needed.
+- **ΔHdg** is the arc angle — use it as the `angle` parameter.
+- The Field Mapper does not auto-detect turn direction: use **positive radius for clockwise**, **negative for counter-clockwise**.
+
+### Notes
+
+- Only active under `GuiDebug` (`TESTING_AUTONOMOUS true`). No-op on base `Gui`.
+- Call `setMapDataProvider()` **before** `aon::gui->initialize()`.
+- Buffer holds up to 1 000 points; once full, new points are dropped until **CLEAR** is pressed.
+- Arc results use `DRIVE_WIDTH` from `constants.hpp` for Inner/Out values, so they automatically reflect whichever robot is selected via `USING_BIG_ROBOT`.
+
+---
+
 ## Complete Example
 
 ```cpp

--- a/include/aon/tools/gui/gui-debug.hpp
+++ b/include/aon/tools/gui/gui-debug.hpp
@@ -64,14 +64,8 @@ public:
 
   // ── Field Mapper ──────────────────────────────────────────────────────────
 
-  struct MapPoint {
-    double x;      // inches, field-center origin
-    double y;      // inches, field-center origin
-    double theta;  // radians (same as Pose)
-  };
-
   static constexpr int MAP_BUFFER_SIZE = 600;
-  MapPoint mapBuffer[MAP_BUFFER_SIZE] = {};
+  Pose mapBuffer[MAP_BUFFER_SIZE] = {};
   int      mapBufferCount  = 0;   // number of valid points (0..MAP_BUFFER_SIZE)
   double   mapTotalDist    = 0.0; // cumulative distance traveled (inches)
 
@@ -99,7 +93,7 @@ public:
   void setMapDataProvider(std::function<Pose()> getPose) override;
 
   // Append a new pose sample; computes running distance
-  void AddMapPoint(double x, double y, double theta);
+  void AddMapPoint(double x, double y, double theta);  // theta in degrees (matches Pose)
 
   // Erase all recorded path data and reset arc state
   void ClearMapPath();
@@ -135,29 +129,12 @@ public:
   void HandleDataMenuTouch();
   void HandleFieldMapperTouch();
 
-  // API: register a variable to be editable in Debug Menu 3.
-  // T must support + and - (detected via std::void_t).
-  template <
-    typename T,
-    typename = std::void_t<
-      decltype(std::declval<T>() + std::declval<T>()),
-      decltype(std::declval<T>() - std::declval<T>())
-    >
-  >
-  void variableChanger(T& variableRef, const std::string& name) {
+  // Override the type-erased virtual; called by the template in the base class
+  void variableChangerImpl(const std::string& name,std::function<double()> get,std::function<void(double)> apply) override {
     for (const auto& e : variableEntries) {
       if (e.name == name) return;
     }
-    variableEntries.push_back({
-      name,
-      [&variableRef]() -> double { return static_cast<double>(variableRef); },
-      [&variableRef](double delta) { variableRef += static_cast<T>(delta); }
-    });
-  }
-
-  // Override the virtual base to ensure calls through Gui* hit the template above
-  void variableChanger(double& variableRef, const std::string& name) override {
-    variableChanger<double>(variableRef, name);
+    variableEntries.push_back({name, std::move(get), std::move(apply)});
   }
 
   // Allow user code to provide a register

--- a/include/aon/tools/gui/gui-debug.hpp
+++ b/include/aon/tools/gui/gui-debug.hpp
@@ -76,10 +76,16 @@ public:
   double   mapTotalDist    = 0.0; // cumulative distance traveled (inches)
 
   // Arc measurement state
-  int  arcStartIndex = -1;  // index into mapBuffer where arc mark was set; -1 = not set
+  enum class MapMode { SELECT, DISPLACEMENT, ARC };
+  MapMode mapMode = MapMode::SELECT;
+
+  int  arcStartIndex = -1;  // index into mapBuffer where arc/disp start was set; -1 = not set
+  int  dispEndIndex  = -1;  // index into mapBuffer where disp end was set; -1 = not set
   bool arcMeasured   = false;
   struct ArcResult {
-    double radius;       // inches (0 = straight)
+    double radius;       // inches — robot center (pass directly to driveInArc)
+    double innerRadius;  // inches — inner drive wheel
+    double outerRadius;  // inches — outer drive wheel
     double arcLength;    // inches
     double chordLength;  // inches
     double deltaHeading; // degrees

--- a/include/aon/tools/gui/gui-debug.hpp
+++ b/include/aon/tools/gui/gui-debug.hpp
@@ -2,6 +2,7 @@
 #ifndef AON_TOOLS_GUI_DEBUG_HPP_
 #define AON_TOOLS_GUI_DEBUG_HPP_
 #include "gui.hpp"
+#include "aon/math/pose.hpp"
 #include <map>
 #include <string>
 #include <type_traits>
@@ -61,6 +62,42 @@ public:
   // Invoke the active reset handler (no-op if not set or not found)
   void invokeResetHandler() { auto it = resetHandlers.find(activeResetHandlerName); if (it != resetHandlers.end()) it->second(); }
 
+  // ── Field Mapper ──────────────────────────────────────────────────────────
+
+  struct MapPoint {
+    double x;      // inches, field-center origin
+    double y;      // inches, field-center origin
+    double theta;  // radians (same as Pose)
+  };
+
+  static constexpr int MAP_BUFFER_SIZE = 600;
+  MapPoint mapBuffer[MAP_BUFFER_SIZE] = {};
+  int      mapBufferCount  = 0;   // number of valid points (0..MAP_BUFFER_SIZE)
+  double   mapTotalDist    = 0.0; // cumulative distance traveled (inches)
+
+  // Arc measurement state
+  int  arcStartIndex = -1;  // index into mapBuffer where arc mark was set; -1 = not set
+  bool arcMeasured   = false;
+  struct ArcResult {
+    double radius;       // inches (0 = straight)
+    double arcLength;    // inches
+    double chordLength;  // inches
+    double deltaHeading; // degrees
+    bool   valid = false;
+  } arcResult = {};
+
+  // User provides live pose via this callback
+  std::function<Pose()> mapGetPose = nullptr;
+
+  // Register the pose provider (called once in globals/opcontrol setup)
+  void setMapDataProvider(std::function<Pose()> getPose) override;
+
+  // Append a new pose sample; computes running distance
+  void AddMapPoint(double x, double y, double theta);
+
+  // Erase all recorded path data and reset arc state
+  void ClearMapPath();
+
   // Constructor
   GuiDebug() = default; // Default to use TESTING_AUTONOMOUS for conditional display
   virtual ~GuiDebug() = default;
@@ -78,6 +115,7 @@ public:
   void DisplayLiveGraph();
   void DisplayVariablesMenu();
   void DisplayDataMenu();
+  void DisplayFieldMapper();
 
   // Override main menu touch handler to handle DEBUG button
   virtual void handleMainMenuTouch(const pros::screen_touch_status_s_t& touchStatus) override;
@@ -89,6 +127,7 @@ public:
   void HandleLiveGraphTouch();
   void HandleVariablesMenuTouch();
   void HandleDataMenuTouch();
+  void HandleFieldMapperTouch();
 
   // API: register a variable to be editable in Debug Menu 3.
   // T must support + and - (detected via std::void_t).

--- a/include/aon/tools/gui/gui-debug.hpp
+++ b/include/aon/tools/gui/gui-debug.hpp
@@ -155,6 +155,11 @@ public:
     });
   }
 
+  // Override the virtual base to ensure calls through Gui* hit the template above
+  void variableChanger(double& variableRef, const std::string& name) override {
+    variableChanger<double>(variableRef, name);
+  }
+
   // Allow user code to provide a register
   void setVariableRegister(const std::function<void()>& Register);
 

--- a/include/aon/tools/gui/gui.hpp
+++ b/include/aon/tools/gui/gui.hpp
@@ -115,12 +115,21 @@ public:
   virtual void handleRedAutonMenuTouch();
   virtual void handleBlueAutonMenuTouch();
   virtual void handleSkillsMenuTouch();
-
-  // Debug-related APIs (no-op defaults). These are implemented fully in
-  // `GuiDebug`. Declaring them here lets user code call them whether the
-  // concrete GUI is `Gui` or `GuiDebug`.
-  virtual void setVariableRegister(const std::function<void()>& /*Register*/ ) {}
-  virtual void variableChanger(double& /*variableRef*/, const std::string& /*name*/) {}
+  virtual void setVariableRegister(const std::function<void()>&) {}
+  virtual void variableChangerImpl(const std::string&,std::function<double()>,std::function<void(double)>) {}
+  template <
+    typename T,
+    typename = std::void_t<
+      decltype(std::declval<T>() + std::declval<T>()),
+      decltype(std::declval<T>() - std::declval<T>())
+    >
+  >
+  void variableChanger(T& variableRef, const std::string& name) {
+    variableChangerImpl(name,
+      [&variableRef]() -> double { return static_cast<double>(variableRef); },
+      [&variableRef](double delta) { variableRef += static_cast<T>(delta); }
+    );
+  }
   virtual void setTestRegister(const std::function<void()>& /*Register*/ ) {}
   virtual void registerTestFunction(int (* /*func*/)(), const std::string& /*name*/) {}
   virtual void registerTestFunction(const std::function<int()>& /*func*/, const std::string& /*name*/) {}

--- a/include/aon/tools/gui/gui.hpp
+++ b/include/aon/tools/gui/gui.hpp
@@ -9,6 +9,7 @@
 #include <functional>
 #include "../../../api.h"
 #include "aon/constants.hpp"
+#include "aon/math/pose.hpp"
 #include "../function-reader.hpp"
 #include "../gui-image-generator/gui-images.hpp"
 
@@ -40,6 +41,7 @@ enum GuiScreen {
   VARS,
   DATA,
   LiveGraph,
+  FieldMapper,
 };
 
 // Auton selection system
@@ -125,6 +127,7 @@ public:
   virtual void setDataRegister(const std::function<void()>& /*Register*/) {}
   virtual void registerResetHandler(const std::string& /*name*/, const std::function<void()>& /*cb*/) {}
   virtual void invokeResetHandler() {}
+  virtual void setMapDataProvider(std::function<Pose()> /*getPose*/) {}
 
   // Auton selection helper
   void selectAutonByList(Alliance alliance, int index1Based);

--- a/src/aon/tools/gui/debug-tools/autonrunner.cpp
+++ b/src/aon/tools/gui/debug-tools/autonrunner.cpp
@@ -138,6 +138,14 @@ void GuiDebug::DisplayAutonRunner() {
   pros::screen::set_pen(COLOR_BLACK);
   pros::screen::print(pros::E_TEXT_MEDIUM, vcX1 + 18, vcY1 + 8, "VARS");
 
+    // RESET button
+  const int resetY1 = vcY2 + 10, resetY2 = resetY1 + 40;
+  const int resetX1 = vcX1, resetX2 = vcX2;
+  pros::screen::set_eraser(COLOR_RED);
+  pros::screen::erase_rect(resetX1, resetY1, resetX2, resetY2);
+  pros::screen::set_pen(COLOR_WHITE);
+  pros::screen::print(pros::E_TEXT_MEDIUM, resetX1 + 8, resetY1 + 8, "RESET");
+
   // Bottom RUN/MOV button - centered
   const int btnY1 = BRAIN_SCREEN_HEIGHT - 70;
   const int btnY2 = BRAIN_SCREEN_HEIGHT - 20;
@@ -268,6 +276,20 @@ void GuiDebug::HandleAutonRunnerTouch() {
     }
   }
 
+    // RESET button
+  {
+    const int vcY2 = 70 + 40;
+    const int resetY1 = vcY2 + 10, resetY2 = resetY1 + 40;
+    const int resetX1 = BRAIN_SCREEN_WIDTH - 140, resetX2 = BRAIN_SCREEN_WIDTH - 40;
+    if (x >= resetX1 && x <= resetX2 && y >= resetY1 && y <= resetY2) {
+      invokeResetHandler();
+      DisplayAutonRunner();
+      pros::delay(300);
+      return;
+    }
+  }
+
+  
   // Bottom RUN/MOV button coordinates (must match display)
   const int btnY1 = BRAIN_SCREEN_HEIGHT - 70;
   const int btnY2 = BRAIN_SCREEN_HEIGHT - 20;

--- a/src/aon/tools/gui/debug-tools/autonrunner.cpp
+++ b/src/aon/tools/gui/debug-tools/autonrunner.cpp
@@ -131,16 +131,16 @@ void GuiDebug::DisplayAutonRunner() {
   }
 
   // VARS button
-  const int vcY1 = 70, vcY2 = vcY1 + 40;
-  const int vcX1 = BRAIN_SCREEN_WIDTH - 140, vcX2 = BRAIN_SCREEN_WIDTH - 40;
+  const int varsY1 = 70, varsY2 = varsY1 + 40;
+  const int varsX1 = BRAIN_SCREEN_WIDTH - 140, varsX2 = BRAIN_SCREEN_WIDTH - 40;
   pros::screen::set_eraser(COLOR_ORANGE);
-  pros::screen::erase_rect(vcX1, vcY1, vcX2, vcY2);
+  pros::screen::erase_rect(varsX1, varsY1, varsX2, varsY2);
   pros::screen::set_pen(COLOR_BLACK);
-  pros::screen::print(pros::E_TEXT_MEDIUM, vcX1 + 18, vcY1 + 8, "VARS");
+  pros::screen::print(pros::E_TEXT_MEDIUM, varsX1 + 18, varsY1 + 8, "VARS");
 
-    // RESET button
-  const int resetY1 = vcY2 + 10, resetY2 = resetY1 + 40;
-  const int resetX1 = vcX1, resetX2 = vcX2;
+  // RESET button
+  const int resetY1 = varsY2 + 10, resetY2 = resetY1 + 40;
+  const int resetX1 = varsX1, resetX2 = varsX2;
   pros::screen::set_eraser(COLOR_RED);
   pros::screen::erase_rect(resetX1, resetY1, resetX2, resetY2);
   pros::screen::set_pen(COLOR_WHITE);
@@ -262,9 +262,9 @@ void GuiDebug::HandleAutonRunnerTouch() {
 
   // VARS button
   {
-    const int vcY1 = 70, vcY2 = vcY1 + 40;
-    const int vcX1 = BRAIN_SCREEN_WIDTH - 140, vcX2 = BRAIN_SCREEN_WIDTH - 40;
-    if (x >= vcX1 && x <= vcX2 && y >= vcY1 && y <= vcY2) {
+    const int varsY1 = 70, varsY2 = varsY1 + 40;
+    const int varsX1 = BRAIN_SCREEN_WIDTH - 140, varsX2 = BRAIN_SCREEN_WIDTH - 40;
+    if (x >= varsX1 && x <= varsX2 && y >= varsY1 && y <= varsY2) {
       if (variableEntries.empty() && variableRegister) {
         variableRegister();
       }
@@ -278,8 +278,8 @@ void GuiDebug::HandleAutonRunnerTouch() {
 
     // RESET button
   {
-    const int vcY2 = 70 + 40;
-    const int resetY1 = vcY2 + 10, resetY2 = resetY1 + 40;
+    const int varsY2 = 70 + 40;
+    const int resetY1 = varsY2 + 10, resetY2 = resetY1 + 40;
     const int resetX1 = BRAIN_SCREEN_WIDTH - 140, resetX2 = BRAIN_SCREEN_WIDTH - 40;
     if (x >= resetX1 && x <= resetX2 && y >= resetY1 && y <= resetY2) {
       invokeResetHandler();

--- a/src/aon/tools/gui/debug-tools/fieldmapper.cpp
+++ b/src/aon/tools/gui/debug-tools/fieldmapper.cpp
@@ -11,7 +11,7 @@ namespace aon {
 
 // Field view: 200×200 px square, anchored top-left with padding
 static constexpr int  FM_FX1    = 5;    // field view left edge
-static constexpr int  FM_FY1    = 28;   // field view top edge
+static constexpr int  FM_FY1    = 36;   // field view top edge (below 28px header)
 static constexpr int  FM_FSIZE  = 200;  // pixel width/height of the field square
 static constexpr int  FM_FX2    = FM_FX1  + FM_FSIZE;
 static constexpr int  FM_FY2    = FM_FY1  + FM_FSIZE;
@@ -77,27 +77,30 @@ static void computeArc(const GuiDebug::MapPoint* buf, int start, int end,
 }
 
 // ============================================================================
-// Display
+// DISPLAY FUNCTIONS
 // ============================================================================
 
 void GuiDebug::DisplayFieldMapper() {
   pros::screen::set_eraser(COLOR_BLACK);
   pros::screen::erase();
 
-  // ── Header bar ────────────────────────────────────────────────────────────
-  // [BACK]  FIELD MAPPER  [CLEAR]
+  // Header
+  pros::screen::set_pen(COLOR_WHITE);
+  pros::screen::print(pros::E_TEXT_MEDIUM, BRAIN_SCREEN_WIDTH / 2 - 55, 10, "FIELD MAPPER");
+
+  // BACK button
+  const int backX1 = 10, backY1 = 6, backX2 = backX1 + 80, backY2 = backY1 + 28;
   pros::screen::set_eraser(COLOR_DARK_GRAY);
-  pros::screen::erase_rect(5, 2, 70, 24);
+  pros::screen::erase_rect(backX1, backY1, backX2, backY2);
   pros::screen::set_pen(COLOR_WHITE);
-  pros::screen::print(pros::E_TEXT_SMALL, 14, 8, "BACK");
+  pros::screen::print(pros::E_TEXT_MEDIUM, backX1 + 10, backY1 + 6, "BACK");
 
+  // CLEAR button
+  const int clearX1 = BRAIN_SCREEN_WIDTH - 90, clearY1 = 6, clearX2 = BRAIN_SCREEN_WIDTH - 10, clearY2 = clearY1 + 28;
   pros::screen::set_eraser(COLOR_RED);
-  pros::screen::erase_rect(BRAIN_SCREEN_WIDTH - 75, 2, BRAIN_SCREEN_WIDTH - 5, 24);
+  pros::screen::erase_rect(clearX1, clearY1, clearX2, clearY2);
   pros::screen::set_pen(COLOR_WHITE);
-  pros::screen::print(pros::E_TEXT_SMALL, BRAIN_SCREEN_WIDTH - 63, 8, "CLEAR");
-
-  pros::screen::set_pen(COLOR_WHITE);
-  pros::screen::print(pros::E_TEXT_MEDIUM, BRAIN_SCREEN_WIDTH / 2 - 55, 5, "FIELD MAPPER");
+  pros::screen::print(pros::E_TEXT_MEDIUM, clearX1 + 10, clearY1 + 6, "CLEAR");
 
   // ── Field view ────────────────────────────────────────────────────────────
   // Outer border
@@ -380,85 +383,92 @@ void GuiDebug::DisplayFieldMapper() {
 }
 
 // ============================================================================
-// Touch Handler
+// TOUCH HANDLERS
 // ============================================================================
 
 void GuiDebug::HandleFieldMapperTouch() {
-  pros::screen_touch_status_s_t touch = pros::screen::touch_status();
+  const auto touch = pros::screen::touch_status();
   if (touch.touch_status <= 0) return;
 
-  static uint32_t lastTouchMs = 0;
-  uint32_t now = pros::millis();
-  if (now - lastTouchMs < 300) return;
-  lastTouchMs = now;
+  int x = touch.x;
+  int y = touch.y;
 
-  int tx = touch.x;
-  int ty = touch.y;
-
-  // ── BACK button (top-left) ────────────────────────────────────────────────
-  if (tx >= 5 && tx <= 70 && ty >= 2 && ty <= 24) {
-    DisplayDebugMenu();
-    currentScreen = DebugMenu;
-    return;
-  }
-
-  // ── CLEAR button (top-right) ──────────────────────────────────────────────
-  if (tx >= BRAIN_SCREEN_WIDTH - 75 && tx <= BRAIN_SCREEN_WIDTH - 5 &&
-      ty >= 2 && ty <= 24) {
-    ClearMapPath();
-    DisplayFieldMapper();
-    return;
-  }
-
-  // ── MARK START / MARK END / DISPLACE / ARC MEAS buttons ─────────────────
-  const int btnY1 = BRAIN_SCREEN_HEIGHT - 35;
-  const int btnY2 = BRAIN_SCREEN_HEIGHT - 5;
-  const int halfW = (FM_DW - 6) / 2;
-  const int markSX2 = FM_DX + halfW;
-  const int markEX1 = FM_DX + halfW + 6;
-  const int markEX2 = FM_DX + FM_DW;
-
-  if (tx >= FM_DX && tx <= markSX2 && ty >= btnY1 && ty <= btnY2) {
-    if (mapMode == MapMode::SELECT) {
-      // Enter DISPLACEMENT mode
-      mapMode = MapMode::DISPLACEMENT;
-      arcStartIndex = -1;
-      dispEndIndex  = -1;
-    } else if (mapMode == MapMode::DISPLACEMENT) {
-      // MARK START
-      arcStartIndex = (mapBufferCount > 0) ? mapBufferCount - 1 : 0;
-      dispEndIndex  = -1;
-    } else if (mapMode == MapMode::ARC) {
-      // MARK START
-      arcStartIndex = (mapBufferCount > 0) ? mapBufferCount - 1 : 0;
-      arcMeasured   = false;
-      arcResult     = {};
+  // BACK button
+  {
+    const int backX1 = 10, backY1 = 6, backX2 = backX1 + 80, backY2 = backY1 + 28;
+    if (x >= backX1 && x <= backX2 && y >= backY1 && y <= backY2) {
+      DisplayDebugMenu();
+      currentScreen = DebugMenu;
+      pros::delay(300);
+      return;
     }
-    DisplayFieldMapper();
-    return;
   }
 
-  if (tx >= markEX1 && tx <= markEX2 && ty >= btnY1 && ty <= btnY2) {
-    if (mapMode == MapMode::SELECT) {
-      // Enter ARC mode
-      mapMode = MapMode::ARC;
-      arcStartIndex = -1;
-      arcMeasured   = false;
-      arcResult     = {};
-    } else if (mapMode == MapMode::DISPLACEMENT) {
-      // MARK END for displacement
-      if (arcStartIndex >= 0 && mapBufferCount > arcStartIndex) {
-        dispEndIndex = mapBufferCount - 1;
-      }
-    } else if (mapMode == MapMode::ARC) {
-      // MARK END — compute arc
-      if (arcStartIndex >= 0 && mapBufferCount > arcStartIndex + 1) {
-        computeArc(mapBuffer, arcStartIndex, mapBufferCount - 1, arcResult);
-        arcMeasured = arcResult.valid;
-      }
+  // CLEAR button
+  {
+    const int clearX1 = BRAIN_SCREEN_WIDTH - 90, clearY1 = 6;
+    const int clearX2 = BRAIN_SCREEN_WIDTH - 10, clearY2 = clearY1 + 28;
+    if (x >= clearX1 && x <= clearX2 && y >= clearY1 && y <= clearY2) {
+      ClearMapPath();
+      DisplayFieldMapper();
+      pros::delay(300);
+      return;
     }
-    DisplayFieldMapper();
-    return;
+  }
+
+  // Mode / Mark buttons (bottom of data panel)
+  {
+    const int btnY1 = BRAIN_SCREEN_HEIGHT - 35;
+    const int btnY2 = BRAIN_SCREEN_HEIGHT - 5;
+    const int halfW = (FM_DW - 6) / 2;
+    const int markSX2 = FM_DX + halfW;
+    const int markEX1 = FM_DX + halfW + 6;
+    const int markEX2 = FM_DX + FM_DW;
+
+    if (x >= FM_DX && x <= markSX2 && y >= btnY1 && y <= btnY2) {
+      if (mapMode == MapMode::SELECT) {
+        // Enter DISPLACEMENT mode
+        mapMode = MapMode::DISPLACEMENT;
+        arcStartIndex = -1;
+        dispEndIndex  = -1;
+      } else if (mapMode == MapMode::DISPLACEMENT) {
+        // MARK START
+        arcStartIndex = (mapBufferCount > 0) ? mapBufferCount - 1 : 0;
+        dispEndIndex  = -1;
+      } else if (mapMode == MapMode::ARC) {
+        // MARK START
+        arcStartIndex = (mapBufferCount > 0) ? mapBufferCount - 1 : 0;
+        arcMeasured   = false;
+        arcResult     = {};
+      }
+      DisplayFieldMapper();
+      pros::delay(300);
+      return;
+    }
+
+    if (x >= markEX1 && x <= markEX2 && y >= btnY1 && y <= btnY2) {
+      if (mapMode == MapMode::SELECT) {
+        // Enter ARC mode
+        mapMode = MapMode::ARC;
+        arcStartIndex = -1;
+        arcMeasured   = false;
+        arcResult     = {};
+      } else if (mapMode == MapMode::DISPLACEMENT) {
+        // MARK END for displacement
+        if (arcStartIndex >= 0 && mapBufferCount > arcStartIndex) {
+          dispEndIndex = mapBufferCount - 1;
+        }
+      } else if (mapMode == MapMode::ARC) {
+        // MARK END — compute arc
+        if (arcStartIndex >= 0 && mapBufferCount > arcStartIndex + 1) {
+          computeArc(mapBuffer, arcStartIndex, mapBufferCount - 1, arcResult);
+          arcMeasured = arcResult.valid;
+        }
+      }
+      DisplayFieldMapper();
+      pros::delay(300);
+      return;
+    }
   }
 }
 

--- a/src/aon/tools/gui/debug-tools/fieldmapper.cpp
+++ b/src/aon/tools/gui/debug-tools/fieldmapper.cpp
@@ -29,8 +29,8 @@ static constexpr int  FIELDX2    = FIELDX1  + FSIZE;
 static constexpr int  FIELDY2    = FIELDY1  + FSIZE;
 
 // Data panel sits to the right of the field view
-static constexpr int  DX     = FIELDX2 + 8;  // data panel left edge (x=213)
-static constexpr int  DW     = BRAIN_SCREEN_WIDTH - DX - 4; // ~263 px
+static constexpr int  displayX     = FIELDX2 + 8;  // data panel left edge (x=213)
+static constexpr int  displayW     = BRAIN_SCREEN_WIDTH - displayX - 4; // ~263 px
 
 // Half-field size in inches (6 tiles × TILE_WIDTH / 2)
 static constexpr double FIELD_HALF = 6.0 * TILE_WIDTH / 2.0; // ≈ 70.866 in
@@ -186,7 +186,7 @@ void GuiDebug::DisplayFieldMapper() {
   }
 
   // ── Data panel ────────────────────────────────────────────────────────────
-  const int dx = DX;
+  const int dx = displayX;
   int dy = FIELDY1;
   const int rowH = 22;
 
@@ -229,7 +229,7 @@ void GuiDebug::DisplayFieldMapper() {
 
   // Separator
   pros::screen::set_eraser(COLOR_GRID);
-  pros::screen::erase_rect(dx, dy, dx + DW, dy + 1);
+  pros::screen::erase_rect(dx, dy, dx + displayW, dy + 1);
   dy += 6;
 
   // ── Stats panel ──────────────────────────────────────────────────────────
@@ -347,7 +347,7 @@ void GuiDebug::DisplayFieldMapper() {
   // ── Bottom buttons ────────────────────────────────────────────────────────
   const int btnY1 = BRAIN_SCREEN_HEIGHT - 35;
   const int btnY2 = BRAIN_SCREEN_HEIGHT - 5;
-  const int halfW = (DW - 6) / 2;
+  const int halfW = (displayW - 6) / 2;
 
   if (mapMode == MapMode::SELECT) {
     // [DISPLACE]  [ARC MEAS]
@@ -357,7 +357,7 @@ void GuiDebug::DisplayFieldMapper() {
     pros::screen::print(pros::E_TEXT_SMALL, dx + 4, btnY1 + 8, "DISPLACE");
 
     pros::screen::set_eraser(COLOR_BTN_ARC_IDLE);
-    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + DW, btnY2);
+    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + displayW, btnY2);
     pros::screen::set_pen(COLOR_WHITE);
     pros::screen::print(pros::E_TEXT_SMALL, dx + halfW + 10, btnY1 + 8, "ARC MEAS");
   } else if (mapMode == MapMode::DISPLACEMENT) {
@@ -371,7 +371,7 @@ void GuiDebug::DisplayFieldMapper() {
 
     uint32_t endColor = (dispEndIndex >= 0) ? COLOR_DARK_BLUE : COLOR_BTN_END_IDLE;
     pros::screen::set_eraser(endColor);
-    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + DW, btnY2);
+    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + displayW, btnY2);
     pros::screen::set_pen(COLOR_WHITE);
     pros::screen::print(pros::E_TEXT_SMALL, dx + halfW + 10, btnY1 + 8,
                         (dispEndIndex >= 0) ? "END SET" : "MARK END");
@@ -386,7 +386,7 @@ void GuiDebug::DisplayFieldMapper() {
 
     uint32_t markEColor = arcMeasured ? COLOR_DARK_BLUE : COLOR_BTN_END_IDLE;
     pros::screen::set_eraser(markEColor);
-    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + DW, btnY2);
+    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + displayW, btnY2);
     pros::screen::set_pen(COLOR_WHITE);
     pros::screen::print(pros::E_TEXT_SMALL, dx + halfW + 10, btnY1 + 8, "MARK END");
   }
@@ -430,12 +430,12 @@ void GuiDebug::HandleFieldMapperTouch() {
   {
     const int btnY1 = BRAIN_SCREEN_HEIGHT - 35;
     const int btnY2 = BRAIN_SCREEN_HEIGHT - 5;
-    const int halfW = (DW - 6) / 2;
-    const int startBtnX2 = DX + halfW;          // right edge of start button
-    const int endBtnX1   = DX + halfW + 6;       // left edge of end button
-    const int endBtnX2   = DX + DW;  // right edge of end button
+    const int halfW = (displayW - 6) / 2;
+    const int startBtnX2 = displayX + halfW;          // right edge of start button
+    const int endBtnX1   = displayX + halfW + 6;       // left edge of end button
+    const int endBtnX2   = displayX + displayW;  // right edge of end button
 
-    if (x >= DX && x <= startBtnX2 && y >= btnY1 && y <= btnY2) {
+    if (x >= displayX && x <= startBtnX2 && y >= btnY1 && y <= btnY2) {
       if (mapMode == MapMode::SELECT) {
         // Enter DISPLACEMENT mode
         mapMode = MapMode::DISPLACEMENT;

--- a/src/aon/tools/gui/debug-tools/fieldmapper.cpp
+++ b/src/aon/tools/gui/debug-tools/fieldmapper.cpp
@@ -1,0 +1,342 @@
+#include "../../../../../include/aon/tools/gui/gui-debug.hpp"
+#include "../../../../../include/aon/constants.hpp"
+#include <cmath>
+#include <cstdio>
+
+namespace aon {
+
+// ============================================================================
+// Field Mapper — layout constants
+// ============================================================================
+
+// Field view: 200×200 px square, anchored top-left with padding
+static constexpr int  FM_FX1    = 5;    // field view left edge
+static constexpr int  FM_FY1    = 28;   // field view top edge
+static constexpr int  FM_FSIZE  = 200;  // pixel width/height of the field square
+static constexpr int  FM_FX2    = FM_FX1  + FM_FSIZE;
+static constexpr int  FM_FY2    = FM_FY1  + FM_FSIZE;
+
+// Data panel sits to the right of the field view
+static constexpr int  FM_DX     = FM_FX2 + 8;  // data panel left edge (x=213)
+static constexpr int  FM_DW     = BRAIN_SCREEN_WIDTH - FM_DX - 4; // ~263 px
+
+// Half-field size in inches (6 tiles × TILE_WIDTH / 2)
+static constexpr double FIELD_HALF = 6.0 * TILE_WIDTH / 2.0; // ≈ 70.866 in
+
+// ── Coordinate helpers ──────────────────────────────────────────────────────
+
+static int fieldToScreenX(double x) {
+  return FM_FX1 + static_cast<int>((x + FIELD_HALF) / (2.0 * FIELD_HALF) * FM_FSIZE);
+}
+
+static int fieldToScreenY(double y) {
+  // y increases upward on field, downward on screen → flip
+  return FM_FY2 - static_cast<int>((y + FIELD_HALF) / (2.0 * FIELD_HALF) * FM_FSIZE);
+}
+
+// ── Arc computation ──────────────────────────────────────────────────────────
+
+static void computeArc(const GuiDebug::MapPoint* buf, int start, int end,
+                       GuiDebug::ArcResult& out) {
+  out = {};
+  if (start < 0 || end <= start) return;
+
+  // Arc length = sum of segment distances
+  double arcLen = 0.0;
+  for (int i = start + 1; i <= end; ++i) {
+    double dx = buf[i].x - buf[i - 1].x;
+    double dy = buf[i].y - buf[i - 1].y;
+    arcLen += std::sqrt(dx * dx + dy * dy);
+  }
+
+  // Chord from start to end points
+  double cx = buf[end].x - buf[start].x;
+  double cy = buf[end].y - buf[start].y;
+  double chord = std::sqrt(cx * cx + cy * cy);
+
+  // Heading change (radians → degrees), unwrapped to [0, 360)
+  double dTheta = buf[end].theta - buf[start].theta;
+  // Normalise to (−π, π]
+  while (dTheta >  M_PI) dTheta -= 2.0 * M_PI;
+  while (dTheta < -M_PI) dTheta += 2.0 * M_PI;
+  double dDeg = std::fabs(dTheta) * (180.0 / M_PI);
+
+  // Radius from arc-length / angle (circular arc assumption)
+  double radius = 0.0;
+  if (std::fabs(dTheta) > 0.01) {  // > ~0.57° before assuming straight
+    radius = arcLen / std::fabs(dTheta);
+  }
+
+  out.arcLength    = arcLen;
+  out.chordLength  = chord;
+  out.deltaHeading = dDeg;
+  out.radius       = radius;
+  out.valid        = true;
+}
+
+// ============================================================================
+// Display
+// ============================================================================
+
+void GuiDebug::DisplayFieldMapper() {
+  pros::screen::set_eraser(COLOR_BLACK);
+  pros::screen::erase();
+
+  // ── Header bar ────────────────────────────────────────────────────────────
+  // [BACK]  FIELD MAPPER  [CLEAR]
+  pros::screen::set_eraser(COLOR_DARK_GRAY);
+  pros::screen::erase_rect(5, 2, 70, 24);
+  pros::screen::set_pen(COLOR_WHITE);
+  pros::screen::print(pros::E_TEXT_SMALL, 14, 8, "BACK");
+
+  pros::screen::set_eraser(COLOR_RED);
+  pros::screen::erase_rect(BRAIN_SCREEN_WIDTH - 75, 2, BRAIN_SCREEN_WIDTH - 5, 24);
+  pros::screen::set_pen(COLOR_WHITE);
+  pros::screen::print(pros::E_TEXT_SMALL, BRAIN_SCREEN_WIDTH - 63, 8, "CLEAR");
+
+  pros::screen::set_pen(COLOR_WHITE);
+  pros::screen::print(pros::E_TEXT_MEDIUM, BRAIN_SCREEN_WIDTH / 2 - 55, 5, "FIELD MAPPER");
+
+  // ── Field view ────────────────────────────────────────────────────────────
+  // Outer border
+  pros::screen::set_eraser(COLOR_DARK_GRAY);
+  pros::screen::erase_rect(FM_FX1 - 1, FM_FY1 - 1, FM_FX2 + 1, FM_FY2 + 1);
+  // Field background
+  pros::screen::set_eraser(0x1A1A1A);
+  pros::screen::erase_rect(FM_FX1, FM_FY1, FM_FX2, FM_FY2);
+
+  // Tile grid (6 tiles → 7 lines in each direction)
+  pros::screen::set_pen(0x333333);
+  for (int i = 0; i <= 6; ++i) {
+    int px = FM_FX1 + i * FM_FSIZE / 6;
+    int py = FM_FY1 + i * FM_FSIZE / 6;
+    pros::screen::draw_line(px, FM_FY1, px, FM_FY2);
+    pros::screen::draw_line(FM_FX1, py, FM_FX2, py);
+  }
+
+  // Field origin cross (faint)
+  pros::screen::set_pen(0x444444);
+  int ox = fieldToScreenX(0.0);
+  int oy = fieldToScreenY(0.0);
+  pros::screen::draw_line(ox - 5, oy, ox + 5, oy);
+  pros::screen::draw_line(ox, oy - 5, ox, oy + 5);
+
+  // Path trace
+  if (mapBufferCount > 1) {
+    // Draw arc segment (between arcStartIndex and end) highlighted in yellow
+    for (int i = 1; i < mapBufferCount; ++i) {
+      int x0 = fieldToScreenX(mapBuffer[i - 1].x);
+      int y0 = fieldToScreenY(mapBuffer[i - 1].y);
+      int x1 = fieldToScreenX(mapBuffer[i].x);
+      int y1 = fieldToScreenY(mapBuffer[i].y);
+
+      bool inArc = (arcStartIndex >= 0 && i > arcStartIndex);
+      pros::screen::set_pen(inArc ? COLOR_YELLOW : COLOR_CYAN);
+      pros::screen::draw_line(x0, y0, x1, y1);
+    }
+
+    // Arc start marker (green dot)
+    if (arcStartIndex >= 0 && arcStartIndex < mapBufferCount) {
+      int ax = fieldToScreenX(mapBuffer[arcStartIndex].x);
+      int ay = fieldToScreenY(mapBuffer[arcStartIndex].y);
+      pros::screen::set_pen(COLOR_GREEN);
+      pros::screen::draw_pixel(ax, ay);
+      pros::screen::draw_pixel(ax + 1, ay);
+      pros::screen::draw_pixel(ax, ay + 1);
+      pros::screen::draw_pixel(ax + 1, ay + 1);
+    }
+  }
+
+  // Robot position + heading arrow (most recent point)
+  if (mapBufferCount > 0) {
+    const auto& cur = mapBuffer[mapBufferCount - 1];
+    int rx = fieldToScreenX(cur.x);
+    int ry = fieldToScreenY(cur.y);
+
+    // Heading arrow: theta=0 points in +y direction on field → upward on screen
+    double cosH = std::cos(cur.theta);
+    double sinH = std::sin(cur.theta);
+    int arrowLen = 10;
+    // +y on field = -y on screen; +x on field = +x on screen
+    int ex = rx + static_cast<int>( sinH * arrowLen);
+    int ey = ry - static_cast<int>( cosH * arrowLen);
+
+    pros::screen::set_pen(COLOR_WHITE);
+    pros::screen::draw_line(rx, ry, ex, ey);
+    // Dot at robot center
+    pros::screen::draw_pixel(rx, ry);
+    pros::screen::draw_pixel(rx + 1, ry);
+    pros::screen::draw_pixel(rx, ry + 1);
+    pros::screen::draw_pixel(rx + 1, ry + 1);
+  }
+
+  // ── Data panel ────────────────────────────────────────────────────────────
+  const int dx = FM_DX;
+  int dy = FM_FY1;
+  const int rowH = 22;
+
+  // Current pose values (from last map point, or zeros)
+  double curX = 0.0, curY = 0.0, curHdgDeg = 0.0;
+  if (mapBufferCount > 0) {
+    curX     = mapBuffer[mapBufferCount - 1].x;
+    curY     = mapBuffer[mapBufferCount - 1].y;
+    curHdgDeg = mapBuffer[mapBufferCount - 1].theta * (180.0 / M_PI);
+  }
+
+  char buf[40];
+  pros::screen::set_pen(COLOR_LIGHT_GRAY);
+  pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "X:");
+  pros::screen::set_pen(COLOR_GREEN);
+  snprintf(buf, sizeof(buf), "%.2f\"", curX);
+  pros::screen::print(pros::E_TEXT_SMALL, dx + 20, dy, buf);
+  dy += rowH;
+
+  pros::screen::set_pen(COLOR_LIGHT_GRAY);
+  pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "Y:");
+  pros::screen::set_pen(COLOR_GREEN);
+  snprintf(buf, sizeof(buf), "%.2f\"", curY);
+  pros::screen::print(pros::E_TEXT_SMALL, dx + 20, dy, buf);
+  dy += rowH;
+
+  pros::screen::set_pen(COLOR_LIGHT_GRAY);
+  pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "H:");
+  pros::screen::set_pen(COLOR_GREEN);
+  snprintf(buf, sizeof(buf), "%.1f" "\xb0", curHdgDeg);
+  pros::screen::print(pros::E_TEXT_SMALL, dx + 20, dy, buf);
+  dy += rowH;
+
+  pros::screen::set_pen(COLOR_LIGHT_GRAY);
+  pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "D:");
+  pros::screen::set_pen(COLOR_GREEN);
+  snprintf(buf, sizeof(buf), "%.2f\"", mapTotalDist);
+  pros::screen::print(pros::E_TEXT_SMALL, dx + 20, dy, buf);
+  dy += rowH;
+
+  // Separator
+  pros::screen::set_eraser(0x333333);
+  pros::screen::erase_rect(dx, dy, dx + FM_DW, dy + 1);
+  dy += 6;
+
+  // ── Arc results ──────────────────────────────────────────────────────────
+  if (arcMeasured && arcResult.valid) {
+    pros::screen::set_pen(COLOR_YELLOW);
+    pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "ARC:");
+    dy += rowH;
+
+    // Radius + ΔHdg on the same row
+    pros::screen::set_pen(COLOR_LIGHT_GRAY);
+    pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "Radius:");
+    pros::screen::set_pen(COLOR_YELLOW);
+    if (arcResult.radius > 0.01) {
+      snprintf(buf, sizeof(buf), "%.2f\"", arcResult.radius);
+    } else {
+      snprintf(buf, sizeof(buf), "straight");
+    }
+    pros::screen::print(pros::E_TEXT_SMALL, dx + 56, dy, buf);
+    pros::screen::set_pen(COLOR_LIGHT_GRAY);
+    pros::screen::print(pros::E_TEXT_SMALL, dx + 130, dy, "\xce\x94Hdg:");
+    pros::screen::set_pen(COLOR_YELLOW);
+    snprintf(buf, sizeof(buf), "%.1f" "\xb0", arcResult.deltaHeading);
+    pros::screen::print(pros::E_TEXT_SMALL, dx + 170, dy, buf);
+    dy += rowH;
+
+    pros::screen::set_pen(COLOR_LIGHT_GRAY);
+    pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "ArcLen:");
+    pros::screen::set_pen(COLOR_YELLOW);
+    snprintf(buf, sizeof(buf), "%.2f\"", arcResult.arcLength);
+    pros::screen::print(pros::E_TEXT_SMALL, dx + 56, dy, buf);
+    dy += rowH;
+
+    pros::screen::set_pen(COLOR_LIGHT_GRAY);
+    pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "Chord:");
+    pros::screen::set_pen(COLOR_YELLOW);
+    snprintf(buf, sizeof(buf), "%.2f\"", arcResult.chordLength);
+    pros::screen::print(pros::E_TEXT_SMALL, dx + 48, dy, buf);
+    dy += rowH;
+  } else {
+    pros::screen::set_pen(0x555555);
+    pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "ARC: --");
+    dy += rowH * 4;  // reserve same space
+  }
+
+  // ── Arc control buttons ──────────────────────────────────────────────────
+  const int btnY1 = BRAIN_SCREEN_HEIGHT - 35;
+  const int btnY2 = BRAIN_SCREEN_HEIGHT - 5;
+  const int halfW = (FM_DW - 6) / 2;
+
+  // [MARK S]
+  uint32_t markSColor = (arcStartIndex >= 0) ? COLOR_DARK_GREEN : 0x005500;
+  pros::screen::set_eraser(markSColor);
+  pros::screen::erase_rect(dx, btnY1, dx + halfW, btnY2);
+  pros::screen::set_pen(COLOR_WHITE);
+  pros::screen::print(pros::E_TEXT_SMALL, dx + 4, btnY1 + 8,
+                      (arcStartIndex >= 0) ? "S SET" : "MARK S");
+
+  // [MARK E]
+  uint32_t markEColor = arcMeasured ? COLOR_DARK_BLUE : 0x000055;
+  pros::screen::set_eraser(markEColor);
+  pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + FM_DW, btnY2);
+  pros::screen::set_pen(COLOR_WHITE);
+  pros::screen::print(pros::E_TEXT_SMALL, dx + halfW + 10, btnY1 + 8, "MARK E");
+}
+
+// ============================================================================
+// Touch Handler
+// ============================================================================
+
+void GuiDebug::HandleFieldMapperTouch() {
+  pros::screen_touch_status_s_t touch = pros::screen::touch_status();
+  if (touch.touch_status <= 0) return;
+
+  static uint32_t lastTouchMs = 0;
+  uint32_t now = pros::millis();
+  if (now - lastTouchMs < 300) return;
+  lastTouchMs = now;
+
+  int tx = touch.x;
+  int ty = touch.y;
+
+  // ── BACK button (top-left) ────────────────────────────────────────────────
+  if (tx >= 5 && tx <= 70 && ty >= 2 && ty <= 24) {
+    DisplayDebugMenu();
+    currentScreen = DebugMenu;
+    return;
+  }
+
+  // ── CLEAR button (top-right) ──────────────────────────────────────────────
+  if (tx >= BRAIN_SCREEN_WIDTH - 75 && tx <= BRAIN_SCREEN_WIDTH - 5 &&
+      ty >= 2 && ty <= 24) {
+    ClearMapPath();
+    DisplayFieldMapper();
+    return;
+  }
+
+  // ── MARK START button ─────────────────────────────────────────────────────
+  const int btnY1 = BRAIN_SCREEN_HEIGHT - 35;
+  const int btnY2 = BRAIN_SCREEN_HEIGHT - 5;
+  const int halfW = (FM_DW - 6) / 2;
+  const int markSX2 = FM_DX + halfW;
+  const int markEX1 = FM_DX + halfW + 6;
+  const int markEX2 = FM_DX + FM_DW;
+
+  if (tx >= FM_DX && tx <= markSX2 && ty >= btnY1 && ty <= btnY2) {
+    // Set arc start to the most recent path point
+    arcStartIndex = (mapBufferCount > 0) ? mapBufferCount - 1 : 0;
+    arcMeasured   = false;
+    arcResult     = {};
+    DisplayFieldMapper();
+    return;
+  }
+
+  // ── MARK END button ───────────────────────────────────────────────────────
+  if (tx >= markEX1 && tx <= markEX2 && ty >= btnY1 && ty <= btnY2) {
+    if (arcStartIndex >= 0 && mapBufferCount > arcStartIndex + 1) {
+      computeArc(mapBuffer, arcStartIndex, mapBufferCount - 1, arcResult);
+      arcMeasured = arcResult.valid;
+    }
+    DisplayFieldMapper();
+    return;
+  }
+}
+
+}  // namespace aon

--- a/src/aon/tools/gui/debug-tools/fieldmapper.cpp
+++ b/src/aon/tools/gui/debug-tools/fieldmapper.cpp
@@ -8,29 +8,29 @@ namespace aon {
 // Field Mapper — color constants
 // ============================================================================
 
-static constexpr uint32_t FIELDMAPPER_COLOR_FIELD_BG       = 0x1A1A1A; // field background
-static constexpr uint32_t FIELDMAPPER_COLOR_GRID           = 0x333333; // tile grid lines
-static constexpr uint32_t FIELDMAPPER_COLOR_ORIGIN         = 0x444444; // field origin cross
-static constexpr uint32_t FIELDMAPPER_COLOR_LABEL_DIM      = 0x555555; // placeholder / no-data text
-static constexpr uint32_t FIELDMAPPER_COLOR_LABEL_HINT     = 0x888888; // SELECT mode hint text
-static constexpr uint32_t FIELDMAPPER_COLOR_BTN_DISPLACE   = 0x005566; // DISPLACE button
-static constexpr uint32_t FIELDMAPPER_COLOR_BTN_ARC_IDLE   = 0x005500; // ARC/MARK START inactive
-static constexpr uint32_t FIELDMAPPER_COLOR_BTN_END_IDLE   = 0x000055; // MARK END inactive
+static constexpr uint32_t COLOR_FIELD_BG       = 0x1A1A1A; // field background
+static constexpr uint32_t COLOR_GRID           = 0x333333; // tile grid lines
+static constexpr uint32_t COLOR_ORIGIN         = 0x444444; // field origin cross
+static constexpr uint32_t COLOR_LABEL_DIM      = 0x555555; // placeholder / no-data text
+static constexpr uint32_t COLOR_LABEL_HINT     = 0x888888; // SELECT mode hint text
+static constexpr uint32_t COLOR_BTN_DISPLACE   = 0x005566; // DISPLACE button
+static constexpr uint32_t COLOR_BTN_ARC_IDLE   = 0x005500; // ARC/MARK START inactive
+static constexpr uint32_t COLOR_BTN_END_IDLE   = 0x000055; // MARK END inactive
 
 // ============================================================================
 // Field Mapper — layout constants
 // ============================================================================
 
 // Field view: 200×200 px square, anchored top-left with padding
-static constexpr int  FIELDMAPPER_FIELDX1    = 5;    // field view left edge
-static constexpr int  FIELDMAPPER_FIELDY1    = 36;   // field view top edge (below 28px header)
-static constexpr int  FIELDMAPPER_FSIZE  = 200;  // pixel width/height of the field square
-static constexpr int  FIELDMAPPER_FIELDX2    = FIELDMAPPER_FIELDX1  + FIELDMAPPER_FSIZE;
-static constexpr int  FIELDMAPPER_FIELDY2    = FIELDMAPPER_FIELDY1  + FIELDMAPPER_FSIZE;
+static constexpr int  FIELDX1    = 5;    // field view left edge
+static constexpr int  FIELDY1    = 36;   // field view top edge (below 28px header)
+static constexpr int  FSIZE  = 200;  // pixel width/height of the field square
+static constexpr int  FIELDX2    = FIELDX1  + FSIZE;
+static constexpr int  FIELDY2    = FIELDY1  + FSIZE;
 
 // Data panel sits to the right of the field view
-static constexpr int  FIELDMAPPER_DX     = FIELDMAPPER_FIELDX2 + 8;  // data panel left edge (x=213)
-static constexpr int  FIELDMAPPER_DW     = BRAIN_SCREEN_WIDTH - FIELDMAPPER_DX - 4; // ~263 px
+static constexpr int  DX     = FIELDX2 + 8;  // data panel left edge (x=213)
+static constexpr int  DW     = BRAIN_SCREEN_WIDTH - DX - 4; // ~263 px
 
 // Half-field size in inches (6 tiles × TILE_WIDTH / 2)
 static constexpr double FIELD_HALF = 6.0 * TILE_WIDTH / 2.0; // ≈ 70.866 in
@@ -38,12 +38,12 @@ static constexpr double FIELD_HALF = 6.0 * TILE_WIDTH / 2.0; // ≈ 70.866 in
 // ── Coordinate helpers ──────────────────────────────────────────────────────
 
 static int fieldToScreenX(double x) {
-  return FIELDMAPPER_FIELDX1 + static_cast<int>((x + FIELD_HALF) / (2.0 * FIELD_HALF) * FIELDMAPPER_FSIZE);
+  return FIELDX1 + static_cast<int>((x + FIELD_HALF) / (2.0 * FIELD_HALF) * FSIZE);
 }
 
 static int fieldToScreenY(double y) {
   // y increases upward on field, downward on screen → flip
-  return FIELDMAPPER_FIELDY2 - static_cast<int>((y + FIELD_HALF) / (2.0 * FIELD_HALF) * FIELDMAPPER_FSIZE);
+  return FIELDY2 - static_cast<int>((y + FIELD_HALF) / (2.0 * FIELD_HALF) * FSIZE);
 }
 
 // ── Arc computation ──────────────────────────────────────────────────────────
@@ -117,22 +117,22 @@ void GuiDebug::DisplayFieldMapper() {
   // ── Field view ────────────────────────────────────────────────────────────
   // Outer border
   pros::screen::set_eraser(COLOR_DARK_GRAY);
-  pros::screen::erase_rect(FIELDMAPPER_FIELDX1 - 1, FIELDMAPPER_FIELDY1 - 1, FIELDMAPPER_FIELDX2 + 1, FIELDMAPPER_FIELDY2 + 1);
+  pros::screen::erase_rect(FIELDX1 - 1, FIELDY1 - 1, FIELDX2 + 1, FIELDY2 + 1);
   // Field background
-  pros::screen::set_eraser(FIELDMAPPER_COLOR_FIELD_BG);
-  pros::screen::erase_rect(FIELDMAPPER_FIELDX1, FIELDMAPPER_FIELDY1, FIELDMAPPER_FIELDX2, FIELDMAPPER_FIELDY2);
+  pros::screen::set_eraser(COLOR_FIELD_BG);
+  pros::screen::erase_rect(FIELDX1, FIELDY1, FIELDX2, FIELDY2);
 
   // Tile grid (6 tiles → 7 lines in each direction)
-  pros::screen::set_pen(FIELDMAPPER_COLOR_GRID);
+  pros::screen::set_pen(COLOR_GRID);
   for (int i = 0; i <= 6; ++i) {
-    int px = FIELDMAPPER_FIELDX1 + i * FIELDMAPPER_FSIZE / 6;
-    int py = FIELDMAPPER_FIELDY1 + i * FIELDMAPPER_FSIZE / 6;
-    pros::screen::draw_line(px, FIELDMAPPER_FIELDY1, px, FIELDMAPPER_FIELDY2);
-    pros::screen::draw_line(FIELDMAPPER_FIELDX1, py, FIELDMAPPER_FIELDX2, py);
+    int px = FIELDX1 + i * FSIZE / 6;
+    int py = FIELDY1 + i * FSIZE / 6;
+    pros::screen::draw_line(px, FIELDY1, px, FIELDY2);
+    pros::screen::draw_line(FIELDX1, py, FIELDX2, py);
   }
 
   // Field origin cross (faint)
-  pros::screen::set_pen(FIELDMAPPER_COLOR_ORIGIN);
+  pros::screen::set_pen(COLOR_ORIGIN);
   int ox = fieldToScreenX(0.0);
   int oy = fieldToScreenY(0.0);
   pros::screen::draw_line(ox - 5, oy, ox + 5, oy);
@@ -186,8 +186,8 @@ void GuiDebug::DisplayFieldMapper() {
   }
 
   // ── Data panel ────────────────────────────────────────────────────────────
-  const int dx = FIELDMAPPER_DX;
-  int dy = FIELDMAPPER_FIELDY1;
+  const int dx = DX;
+  int dy = FIELDY1;
   const int rowH = 22;
 
   // Current pose values (from last map point, or zeros)
@@ -228,8 +228,8 @@ void GuiDebug::DisplayFieldMapper() {
   dy += rowH;
 
   // Separator
-  pros::screen::set_eraser(FIELDMAPPER_COLOR_GRID);
-  pros::screen::erase_rect(dx, dy, dx + FIELDMAPPER_DW, dy + 1);
+  pros::screen::set_eraser(COLOR_GRID);
+  pros::screen::erase_rect(dx, dy, dx + DW, dy + 1);
   dy += 6;
 
   // ── Stats panel ──────────────────────────────────────────────────────────
@@ -274,11 +274,11 @@ void GuiDebug::DisplayFieldMapper() {
 
       dy += rowH * 2; // padding to match row count
     } else if (arcStartIndex >= 0) {
-      pros::screen::set_pen(FIELDMAPPER_COLOR_LABEL_DIM);
+      pros::screen::set_pen(COLOR_LABEL_DIM);
       pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "-- mark end --");
       dy += rowH * 3;
     } else {
-      pros::screen::set_pen(FIELDMAPPER_COLOR_LABEL_DIM);
+      pros::screen::set_pen(COLOR_LABEL_DIM);
       pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "-- mark start --");
       dy += rowH * 3;
     }
@@ -333,13 +333,13 @@ void GuiDebug::DisplayFieldMapper() {
       }
       dy += rowH;
     } else {
-      pros::screen::set_pen(FIELDMAPPER_COLOR_LABEL_DIM);
+      pros::screen::set_pen(COLOR_LABEL_DIM);
       pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "ARC: --");
       dy += rowH * 4;
     }
   } else {
     // SELECT mode — prompt
-    pros::screen::set_pen(FIELDMAPPER_COLOR_LABEL_HINT);
+    pros::screen::set_pen(COLOR_LABEL_HINT);
     pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "Select mode below:");
     dy += rowH * 4;
   }
@@ -347,46 +347,46 @@ void GuiDebug::DisplayFieldMapper() {
   // ── Bottom buttons ────────────────────────────────────────────────────────
   const int btnY1 = BRAIN_SCREEN_HEIGHT - 35;
   const int btnY2 = BRAIN_SCREEN_HEIGHT - 5;
-  const int halfW = (FIELDMAPPER_DW - 6) / 2;
+  const int halfW = (DW - 6) / 2;
 
   if (mapMode == MapMode::SELECT) {
     // [DISPLACE]  [ARC MEAS]
-    pros::screen::set_eraser(FIELDMAPPER_COLOR_BTN_DISPLACE);
+    pros::screen::set_eraser(COLOR_BTN_DISPLACE);
     pros::screen::erase_rect(dx, btnY1, dx + halfW, btnY2);
     pros::screen::set_pen(COLOR_WHITE);
     pros::screen::print(pros::E_TEXT_SMALL, dx + 4, btnY1 + 8, "DISPLACE");
 
-    pros::screen::set_eraser(FIELDMAPPER_COLOR_BTN_ARC_IDLE);
-    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + FIELDMAPPER_DW, btnY2);
+    pros::screen::set_eraser(COLOR_BTN_ARC_IDLE);
+    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + DW, btnY2);
     pros::screen::set_pen(COLOR_WHITE);
     pros::screen::print(pros::E_TEXT_SMALL, dx + halfW + 10, btnY1 + 8, "ARC MEAS");
   } else if (mapMode == MapMode::DISPLACEMENT) {
     // [MARK START]  [MARK END]
-    uint32_t startColor = (arcStartIndex >= 0) ? COLOR_DARK_GREEN : FIELDMAPPER_COLOR_BTN_ARC_IDLE;
+    uint32_t startColor = (arcStartIndex >= 0) ? COLOR_DARK_GREEN : COLOR_BTN_ARC_IDLE;
     pros::screen::set_eraser(startColor);
     pros::screen::erase_rect(dx, btnY1, dx + halfW, btnY2);
     pros::screen::set_pen(COLOR_WHITE);
     pros::screen::print(pros::E_TEXT_SMALL, dx + 4, btnY1 + 8,
                         (arcStartIndex >= 0) ? "START SET" : "MARK START");
 
-    uint32_t endColor = (dispEndIndex >= 0) ? COLOR_DARK_BLUE : FIELDMAPPER_COLOR_BTN_END_IDLE;
+    uint32_t endColor = (dispEndIndex >= 0) ? COLOR_DARK_BLUE : COLOR_BTN_END_IDLE;
     pros::screen::set_eraser(endColor);
-    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + FIELDMAPPER_DW, btnY2);
+    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + DW, btnY2);
     pros::screen::set_pen(COLOR_WHITE);
     pros::screen::print(pros::E_TEXT_SMALL, dx + halfW + 10, btnY1 + 8,
                         (dispEndIndex >= 0) ? "END SET" : "MARK END");
   } else {
     // ARC mode — [MARK START]  [MARK END]
-    uint32_t markSColor = (arcStartIndex >= 0) ? COLOR_DARK_GREEN : FIELDMAPPER_COLOR_BTN_ARC_IDLE;
+    uint32_t markSColor = (arcStartIndex >= 0) ? COLOR_DARK_GREEN : COLOR_BTN_ARC_IDLE;
     pros::screen::set_eraser(markSColor);
     pros::screen::erase_rect(dx, btnY1, dx + halfW, btnY2);
     pros::screen::set_pen(COLOR_WHITE);
     pros::screen::print(pros::E_TEXT_SMALL, dx + 4, btnY1 + 8,
                         (arcStartIndex >= 0) ? "START SET" : "MARK START");
 
-    uint32_t markEColor = arcMeasured ? COLOR_DARK_BLUE : FIELDMAPPER_COLOR_BTN_END_IDLE;
+    uint32_t markEColor = arcMeasured ? COLOR_DARK_BLUE : COLOR_BTN_END_IDLE;
     pros::screen::set_eraser(markEColor);
-    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + FIELDMAPPER_DW, btnY2);
+    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + DW, btnY2);
     pros::screen::set_pen(COLOR_WHITE);
     pros::screen::print(pros::E_TEXT_SMALL, dx + halfW + 10, btnY1 + 8, "MARK END");
   }
@@ -430,12 +430,12 @@ void GuiDebug::HandleFieldMapperTouch() {
   {
     const int btnY1 = BRAIN_SCREEN_HEIGHT - 35;
     const int btnY2 = BRAIN_SCREEN_HEIGHT - 5;
-    const int halfW = (FIELDMAPPER_DW - 6) / 2;
-    const int startBtnX2 = FIELDMAPPER_DX + halfW;          // right edge of start button
-    const int endBtnX1   = FIELDMAPPER_DX + halfW + 6;       // left edge of end button
-    const int endBtnX2   = FIELDMAPPER_DX + FIELDMAPPER_DW;  // right edge of end button
+    const int halfW = (DW - 6) / 2;
+    const int startBtnX2 = DX + halfW;          // right edge of start button
+    const int endBtnX1   = DX + halfW + 6;       // left edge of end button
+    const int endBtnX2   = DX + DW;  // right edge of end button
 
-    if (x >= FIELDMAPPER_DX && x <= startBtnX2 && y >= btnY1 && y <= btnY2) {
+    if (x >= DX && x <= startBtnX2 && y >= btnY1 && y <= btnY2) {
       if (mapMode == MapMode::SELECT) {
         // Enter DISPLACEMENT mode
         mapMode = MapMode::DISPLACEMENT;

--- a/src/aon/tools/gui/debug-tools/fieldmapper.cpp
+++ b/src/aon/tools/gui/debug-tools/fieldmapper.cpp
@@ -71,6 +71,8 @@ static void computeArc(const GuiDebug::MapPoint* buf, int start, int end,
   out.chordLength  = chord;
   out.deltaHeading = dDeg;
   out.radius       = radius;
+  out.innerRadius  = (radius > 0.01) ? radius - (DRIVE_WIDTH / 2.0) : 0.0;
+  out.outerRadius  = (radius > 0.01) ? radius + (DRIVE_WIDTH / 2.0) : 0.0;
   out.valid        = true;
 }
 
@@ -217,67 +219,164 @@ void GuiDebug::DisplayFieldMapper() {
   pros::screen::erase_rect(dx, dy, dx + FM_DW, dy + 1);
   dy += 6;
 
-  // ── Arc results ──────────────────────────────────────────────────────────
-  if (arcMeasured && arcResult.valid) {
-    pros::screen::set_pen(COLOR_YELLOW);
-    pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "ARC:");
+  // ── Stats panel ──────────────────────────────────────────────────────────
+  if (mapMode == MapMode::DISPLACEMENT) {
+    pros::screen::set_pen(COLOR_CYAN);
+    pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "DISPLACE:");
     dy += rowH;
 
-    // Radius + ΔHdg on the same row
-    pros::screen::set_pen(COLOR_LIGHT_GRAY);
-    pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "Radius:");
-    pros::screen::set_pen(COLOR_YELLOW);
-    if (arcResult.radius > 0.01) {
-      snprintf(buf, sizeof(buf), "%.2f\"", arcResult.radius);
+    if (arcStartIndex >= 0 && dispEndIndex > arcStartIndex) {
+      const auto& s = mapBuffer[arcStartIndex];
+      const auto& e = mapBuffer[dispEndIndex];
+      double ddx = e.x - s.x;
+      double ddy = e.y - s.y;
+      double ddTheta = e.theta - s.theta;
+      while (ddTheta >  M_PI) ddTheta -= 2.0 * M_PI;
+      while (ddTheta < -M_PI) ddTheta += 2.0 * M_PI;
+      double hyp = std::sqrt(ddx * ddx + ddy * ddy);
+
+      pros::screen::set_pen(COLOR_LIGHT_GRAY);
+      pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "X:");
+      pros::screen::set_pen(COLOR_CYAN);
+      snprintf(buf, sizeof(buf), "%.2f\"", ddx);
+      pros::screen::print(pros::E_TEXT_SMALL, dx + 16, dy, buf);
+      pros::screen::set_pen(COLOR_LIGHT_GRAY);
+      pros::screen::print(pros::E_TEXT_SMALL, dx + 130, dy, "Hdg:");
+      pros::screen::set_pen(COLOR_CYAN);
+      snprintf(buf, sizeof(buf), "%.1f" "\xb0", ddTheta * (180.0 / M_PI));
+      pros::screen::print(pros::E_TEXT_SMALL, dx + 158, dy, buf);
+      dy += rowH;
+
+      pros::screen::set_pen(COLOR_LIGHT_GRAY);
+      pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "Y:");
+      pros::screen::set_pen(COLOR_CYAN);
+      snprintf(buf, sizeof(buf), "%.2f\"", ddy);
+      pros::screen::print(pros::E_TEXT_SMALL, dx + 16, dy, buf);
+      pros::screen::set_pen(COLOR_LIGHT_GRAY);
+      pros::screen::print(pros::E_TEXT_SMALL, dx + 130, dy, "Hyp:");
+      pros::screen::set_pen(COLOR_CYAN);
+      snprintf(buf, sizeof(buf), "%.2f\"", hyp);
+      pros::screen::print(pros::E_TEXT_SMALL, dx + 158, dy, buf);
+      dy += rowH;
+
+      dy += rowH * 2; // padding to match row count
+    } else if (arcStartIndex >= 0) {
+      pros::screen::set_pen(0x555555);
+      pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "-- mark end --");
+      dy += rowH * 3;
     } else {
-      snprintf(buf, sizeof(buf), "straight");
+      pros::screen::set_pen(0x555555);
+      pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "-- mark start --");
+      dy += rowH * 3;
     }
-    pros::screen::print(pros::E_TEXT_SMALL, dx + 56, dy, buf);
-    pros::screen::set_pen(COLOR_LIGHT_GRAY);
-    pros::screen::print(pros::E_TEXT_SMALL, dx + 130, dy, "\xce\x94Hdg:");
-    pros::screen::set_pen(COLOR_YELLOW);
-    snprintf(buf, sizeof(buf), "%.1f" "\xb0", arcResult.deltaHeading);
-    pros::screen::print(pros::E_TEXT_SMALL, dx + 170, dy, buf);
-    dy += rowH;
+  } else if (mapMode == MapMode::ARC) {
+    if (arcMeasured && arcResult.valid) {
+      pros::screen::set_pen(COLOR_YELLOW);
+      pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "ARC:");
+      dy += rowH;
 
-    pros::screen::set_pen(COLOR_LIGHT_GRAY);
-    pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "ArcLen:");
-    pros::screen::set_pen(COLOR_YELLOW);
-    snprintf(buf, sizeof(buf), "%.2f\"", arcResult.arcLength);
-    pros::screen::print(pros::E_TEXT_SMALL, dx + 56, dy, buf);
-    dy += rowH;
+      // Radius + ΔHdg on the same row
+      pros::screen::set_pen(COLOR_LIGHT_GRAY);
+      pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "Radius:");
+      pros::screen::set_pen(COLOR_YELLOW);
+      if (arcResult.radius > 0.01) {
+        snprintf(buf, sizeof(buf), "%.2f\"", arcResult.radius);
+      } else {
+        snprintf(buf, sizeof(buf), "straight");
+      }
+      pros::screen::print(pros::E_TEXT_SMALL, dx + 56, dy, buf);
+      pros::screen::set_pen(COLOR_LIGHT_GRAY);
+      pros::screen::print(pros::E_TEXT_SMALL, dx + 130, dy, "Hdg:");
+      pros::screen::set_pen(COLOR_YELLOW);
+      snprintf(buf, sizeof(buf), "%.1f" "\xb0", arcResult.deltaHeading);
+      pros::screen::print(pros::E_TEXT_SMALL, dx + 158, dy, buf);
+      dy += rowH;
 
-    pros::screen::set_pen(COLOR_LIGHT_GRAY);
-    pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "Chord:");
-    pros::screen::set_pen(COLOR_YELLOW);
-    snprintf(buf, sizeof(buf), "%.2f\"", arcResult.chordLength);
-    pros::screen::print(pros::E_TEXT_SMALL, dx + 48, dy, buf);
-    dy += rowH;
+      pros::screen::set_pen(COLOR_LIGHT_GRAY);
+      pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "ArcLen:");
+      pros::screen::set_pen(COLOR_YELLOW);
+      snprintf(buf, sizeof(buf), "%.2f\"", arcResult.arcLength);
+      pros::screen::print(pros::E_TEXT_SMALL, dx + 56, dy, buf);
+      if (arcResult.radius > 0.01) {
+        pros::screen::set_pen(COLOR_LIGHT_GRAY);
+        pros::screen::print(pros::E_TEXT_SMALL, dx + 130, dy, "In:");
+        pros::screen::set_pen(COLOR_YELLOW);
+        snprintf(buf, sizeof(buf), "%.2f\"", arcResult.innerRadius);
+        pros::screen::print(pros::E_TEXT_SMALL, dx + 150, dy, buf);
+      }
+      dy += rowH;
+
+      pros::screen::set_pen(COLOR_LIGHT_GRAY);
+      pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "Chord:");
+      pros::screen::set_pen(COLOR_YELLOW);
+      snprintf(buf, sizeof(buf), "%.2f\"", arcResult.chordLength);
+      pros::screen::print(pros::E_TEXT_SMALL, dx + 48, dy, buf);
+      if (arcResult.radius > 0.01) {
+        pros::screen::set_pen(COLOR_LIGHT_GRAY);
+        pros::screen::print(pros::E_TEXT_SMALL, dx + 130, dy, "Out:");
+        pros::screen::set_pen(COLOR_YELLOW);
+        snprintf(buf, sizeof(buf), "%.2f\"", arcResult.outerRadius);
+        pros::screen::print(pros::E_TEXT_SMALL, dx + 154, dy, buf);
+      }
+      dy += rowH;
+    } else {
+      pros::screen::set_pen(0x555555);
+      pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "ARC: --");
+      dy += rowH * 4;
+    }
   } else {
-    pros::screen::set_pen(0x555555);
-    pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "ARC: --");
-    dy += rowH * 4;  // reserve same space
+    // SELECT mode — prompt
+    pros::screen::set_pen(0x888888);
+    pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "Select mode below:");
+    dy += rowH * 4;
   }
 
-  // ── Arc control buttons ──────────────────────────────────────────────────
+  // ── Bottom buttons ────────────────────────────────────────────────────────
   const int btnY1 = BRAIN_SCREEN_HEIGHT - 35;
   const int btnY2 = BRAIN_SCREEN_HEIGHT - 5;
   const int halfW = (FM_DW - 6) / 2;
 
-  // [MARK S]
-  uint32_t markSColor = (arcStartIndex >= 0) ? COLOR_DARK_GREEN : 0x005500;
-  pros::screen::set_eraser(markSColor);
-  pros::screen::erase_rect(dx, btnY1, dx + halfW, btnY2);
-  pros::screen::set_pen(COLOR_WHITE);
-  pros::screen::print(pros::E_TEXT_SMALL, dx + 4, btnY1 + 8,
-                      (arcStartIndex >= 0) ? "S SET" : "MARK S");
+  if (mapMode == MapMode::SELECT) {
+    // [DISPLACE]  [ARC MEAS]
+    pros::screen::set_eraser(0x005566);
+    pros::screen::erase_rect(dx, btnY1, dx + halfW, btnY2);
+    pros::screen::set_pen(COLOR_WHITE);
+    pros::screen::print(pros::E_TEXT_SMALL, dx + 4, btnY1 + 8, "DISPLACE");
 
-  // [MARK E]
-  uint32_t markEColor = arcMeasured ? COLOR_DARK_BLUE : 0x000055;
-  pros::screen::set_eraser(markEColor);
-  pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + FM_DW, btnY2);
-  pros::screen::set_pen(COLOR_WHITE);
-  pros::screen::print(pros::E_TEXT_SMALL, dx + halfW + 10, btnY1 + 8, "MARK E");
+    pros::screen::set_eraser(0x005500);
+    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + FM_DW, btnY2);
+    pros::screen::set_pen(COLOR_WHITE);
+    pros::screen::print(pros::E_TEXT_SMALL, dx + halfW + 10, btnY1 + 8, "ARC MEAS");
+  } else if (mapMode == MapMode::DISPLACEMENT) {
+    // [MARK START]  [MARK END]
+    uint32_t startColor = (arcStartIndex >= 0) ? COLOR_DARK_GREEN : 0x005500;
+    pros::screen::set_eraser(startColor);
+    pros::screen::erase_rect(dx, btnY1, dx + halfW, btnY2);
+    pros::screen::set_pen(COLOR_WHITE);
+    pros::screen::print(pros::E_TEXT_SMALL, dx + 4, btnY1 + 8,
+                        (arcStartIndex >= 0) ? "START SET" : "MARK START");
+
+    uint32_t endColor = (dispEndIndex >= 0) ? COLOR_DARK_BLUE : 0x000055;
+    pros::screen::set_eraser(endColor);
+    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + FM_DW, btnY2);
+    pros::screen::set_pen(COLOR_WHITE);
+    pros::screen::print(pros::E_TEXT_SMALL, dx + halfW + 10, btnY1 + 8,
+                        (dispEndIndex >= 0) ? "END SET" : "MARK END");
+  } else {
+    // ARC mode — [MARK START]  [MARK END]
+    uint32_t markSColor = (arcStartIndex >= 0) ? COLOR_DARK_GREEN : 0x005500;
+    pros::screen::set_eraser(markSColor);
+    pros::screen::erase_rect(dx, btnY1, dx + halfW, btnY2);
+    pros::screen::set_pen(COLOR_WHITE);
+    pros::screen::print(pros::E_TEXT_SMALL, dx + 4, btnY1 + 8,
+                        (arcStartIndex >= 0) ? "START SET" : "MARK START");
+
+    uint32_t markEColor = arcMeasured ? COLOR_DARK_BLUE : 0x000055;
+    pros::screen::set_eraser(markEColor);
+    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + FM_DW, btnY2);
+    pros::screen::set_pen(COLOR_WHITE);
+    pros::screen::print(pros::E_TEXT_SMALL, dx + halfW + 10, btnY1 + 8, "MARK END");
+  }
 }
 
 // ============================================================================
@@ -311,7 +410,7 @@ void GuiDebug::HandleFieldMapperTouch() {
     return;
   }
 
-  // ── MARK START button ─────────────────────────────────────────────────────
+  // ── MARK START / MARK END / DISPLACE / ARC MEAS buttons ─────────────────
   const int btnY1 = BRAIN_SCREEN_HEIGHT - 35;
   const int btnY2 = BRAIN_SCREEN_HEIGHT - 5;
   const int halfW = (FM_DW - 6) / 2;
@@ -320,19 +419,43 @@ void GuiDebug::HandleFieldMapperTouch() {
   const int markEX2 = FM_DX + FM_DW;
 
   if (tx >= FM_DX && tx <= markSX2 && ty >= btnY1 && ty <= btnY2) {
-    // Set arc start to the most recent path point
-    arcStartIndex = (mapBufferCount > 0) ? mapBufferCount - 1 : 0;
-    arcMeasured   = false;
-    arcResult     = {};
+    if (mapMode == MapMode::SELECT) {
+      // Enter DISPLACEMENT mode
+      mapMode = MapMode::DISPLACEMENT;
+      arcStartIndex = -1;
+      dispEndIndex  = -1;
+    } else if (mapMode == MapMode::DISPLACEMENT) {
+      // MARK START
+      arcStartIndex = (mapBufferCount > 0) ? mapBufferCount - 1 : 0;
+      dispEndIndex  = -1;
+    } else if (mapMode == MapMode::ARC) {
+      // MARK START
+      arcStartIndex = (mapBufferCount > 0) ? mapBufferCount - 1 : 0;
+      arcMeasured   = false;
+      arcResult     = {};
+    }
     DisplayFieldMapper();
     return;
   }
 
-  // ── MARK END button ───────────────────────────────────────────────────────
   if (tx >= markEX1 && tx <= markEX2 && ty >= btnY1 && ty <= btnY2) {
-    if (arcStartIndex >= 0 && mapBufferCount > arcStartIndex + 1) {
-      computeArc(mapBuffer, arcStartIndex, mapBufferCount - 1, arcResult);
-      arcMeasured = arcResult.valid;
+    if (mapMode == MapMode::SELECT) {
+      // Enter ARC mode
+      mapMode = MapMode::ARC;
+      arcStartIndex = -1;
+      arcMeasured   = false;
+      arcResult     = {};
+    } else if (mapMode == MapMode::DISPLACEMENT) {
+      // MARK END for displacement
+      if (arcStartIndex >= 0 && mapBufferCount > arcStartIndex) {
+        dispEndIndex = mapBufferCount - 1;
+      }
+    } else if (mapMode == MapMode::ARC) {
+      // MARK END — compute arc
+      if (arcStartIndex >= 0 && mapBufferCount > arcStartIndex + 1) {
+        computeArc(mapBuffer, arcStartIndex, mapBufferCount - 1, arcResult);
+        arcMeasured = arcResult.valid;
+      }
     }
     DisplayFieldMapper();
     return;

--- a/src/aon/tools/gui/debug-tools/fieldmapper.cpp
+++ b/src/aon/tools/gui/debug-tools/fieldmapper.cpp
@@ -4,21 +4,33 @@
 #include <cstdio>
 
 namespace aon {
+// ============================================================================
+// Field Mapper — color constants
+// ============================================================================
+
+static constexpr uint32_t FIELDMAPPER_COLOR_FIELD_BG       = 0x1A1A1A; // field background
+static constexpr uint32_t FIELDMAPPER_COLOR_GRID           = 0x333333; // tile grid lines
+static constexpr uint32_t FIELDMAPPER_COLOR_ORIGIN         = 0x444444; // field origin cross
+static constexpr uint32_t FIELDMAPPER_COLOR_LABEL_DIM      = 0x555555; // placeholder / no-data text
+static constexpr uint32_t FIELDMAPPER_COLOR_LABEL_HINT     = 0x888888; // SELECT mode hint text
+static constexpr uint32_t FIELDMAPPER_COLOR_BTN_DISPLACE   = 0x005566; // DISPLACE button
+static constexpr uint32_t FIELDMAPPER_COLOR_BTN_ARC_IDLE   = 0x005500; // ARC/MARK START inactive
+static constexpr uint32_t FIELDMAPPER_COLOR_BTN_END_IDLE   = 0x000055; // MARK END inactive
 
 // ============================================================================
 // Field Mapper — layout constants
 // ============================================================================
 
 // Field view: 200×200 px square, anchored top-left with padding
-static constexpr int  FM_FX1    = 5;    // field view left edge
-static constexpr int  FM_FY1    = 36;   // field view top edge (below 28px header)
-static constexpr int  FM_FSIZE  = 200;  // pixel width/height of the field square
-static constexpr int  FM_FX2    = FM_FX1  + FM_FSIZE;
-static constexpr int  FM_FY2    = FM_FY1  + FM_FSIZE;
+static constexpr int  FIELDMAPPER_FIELDX1    = 5;    // field view left edge
+static constexpr int  FIELDMAPPER_FIELDY1    = 36;   // field view top edge (below 28px header)
+static constexpr int  FIELDMAPPER_FSIZE  = 200;  // pixel width/height of the field square
+static constexpr int  FIELDMAPPER_FIELDX2    = FIELDMAPPER_FIELDX1  + FIELDMAPPER_FSIZE;
+static constexpr int  FIELDMAPPER_FIELDY2    = FIELDMAPPER_FIELDY1  + FIELDMAPPER_FSIZE;
 
 // Data panel sits to the right of the field view
-static constexpr int  FM_DX     = FM_FX2 + 8;  // data panel left edge (x=213)
-static constexpr int  FM_DW     = BRAIN_SCREEN_WIDTH - FM_DX - 4; // ~263 px
+static constexpr int  FIELDMAPPER_DX     = FIELDMAPPER_FIELDX2 + 8;  // data panel left edge (x=213)
+static constexpr int  FIELDMAPPER_DW     = BRAIN_SCREEN_WIDTH - FIELDMAPPER_DX - 4; // ~263 px
 
 // Half-field size in inches (6 tiles × TILE_WIDTH / 2)
 static constexpr double FIELD_HALF = 6.0 * TILE_WIDTH / 2.0; // ≈ 70.866 in
@@ -26,17 +38,17 @@ static constexpr double FIELD_HALF = 6.0 * TILE_WIDTH / 2.0; // ≈ 70.866 in
 // ── Coordinate helpers ──────────────────────────────────────────────────────
 
 static int fieldToScreenX(double x) {
-  return FM_FX1 + static_cast<int>((x + FIELD_HALF) / (2.0 * FIELD_HALF) * FM_FSIZE);
+  return FIELDMAPPER_FIELDX1 + static_cast<int>((x + FIELD_HALF) / (2.0 * FIELD_HALF) * FIELDMAPPER_FSIZE);
 }
 
 static int fieldToScreenY(double y) {
   // y increases upward on field, downward on screen → flip
-  return FM_FY2 - static_cast<int>((y + FIELD_HALF) / (2.0 * FIELD_HALF) * FM_FSIZE);
+  return FIELDMAPPER_FIELDY2 - static_cast<int>((y + FIELD_HALF) / (2.0 * FIELD_HALF) * FIELDMAPPER_FSIZE);
 }
 
 // ── Arc computation ──────────────────────────────────────────────────────────
 
-static void computeArc(const GuiDebug::MapPoint* buf, int start, int end,
+static void computeArc(const Pose* buf, int start, int end,
                        GuiDebug::ArcResult& out) {
   out = {};
   if (start < 0 || end <= start) return;
@@ -105,22 +117,22 @@ void GuiDebug::DisplayFieldMapper() {
   // ── Field view ────────────────────────────────────────────────────────────
   // Outer border
   pros::screen::set_eraser(COLOR_DARK_GRAY);
-  pros::screen::erase_rect(FM_FX1 - 1, FM_FY1 - 1, FM_FX2 + 1, FM_FY2 + 1);
+  pros::screen::erase_rect(FIELDMAPPER_FIELDX1 - 1, FIELDMAPPER_FIELDY1 - 1, FIELDMAPPER_FIELDX2 + 1, FIELDMAPPER_FIELDY2 + 1);
   // Field background
-  pros::screen::set_eraser(0x1A1A1A);
-  pros::screen::erase_rect(FM_FX1, FM_FY1, FM_FX2, FM_FY2);
+  pros::screen::set_eraser(FIELDMAPPER_COLOR_FIELD_BG);
+  pros::screen::erase_rect(FIELDMAPPER_FIELDX1, FIELDMAPPER_FIELDY1, FIELDMAPPER_FIELDX2, FIELDMAPPER_FIELDY2);
 
   // Tile grid (6 tiles → 7 lines in each direction)
-  pros::screen::set_pen(0x333333);
+  pros::screen::set_pen(FIELDMAPPER_COLOR_GRID);
   for (int i = 0; i <= 6; ++i) {
-    int px = FM_FX1 + i * FM_FSIZE / 6;
-    int py = FM_FY1 + i * FM_FSIZE / 6;
-    pros::screen::draw_line(px, FM_FY1, px, FM_FY2);
-    pros::screen::draw_line(FM_FX1, py, FM_FX2, py);
+    int px = FIELDMAPPER_FIELDX1 + i * FIELDMAPPER_FSIZE / 6;
+    int py = FIELDMAPPER_FIELDY1 + i * FIELDMAPPER_FSIZE / 6;
+    pros::screen::draw_line(px, FIELDMAPPER_FIELDY1, px, FIELDMAPPER_FIELDY2);
+    pros::screen::draw_line(FIELDMAPPER_FIELDX1, py, FIELDMAPPER_FIELDX2, py);
   }
 
   // Field origin cross (faint)
-  pros::screen::set_pen(0x444444);
+  pros::screen::set_pen(FIELDMAPPER_COLOR_ORIGIN);
   int ox = fieldToScreenX(0.0);
   int oy = fieldToScreenY(0.0);
   pros::screen::draw_line(ox - 5, oy, ox + 5, oy);
@@ -159,15 +171,13 @@ void GuiDebug::DisplayFieldMapper() {
     int ry = fieldToScreenY(cur.y);
 
     // Heading arrow: theta=0 points in +y direction on field → upward on screen
-    double cosH = std::cos(cur.theta);
-    double sinH = std::sin(cur.theta);
-    int arrowLen = 10;
     // +y on field = -y on screen; +x on field = +x on screen
-    int ex = rx + static_cast<int>( sinH * arrowLen);
-    int ey = ry - static_cast<int>( cosH * arrowLen);
+    const int arrowLen = 10;
+    int arrowTipX = rx + static_cast<int>(std::sin(cur.theta) * arrowLen);
+    int arrowTipY = ry - static_cast<int>(std::cos(cur.theta) * arrowLen);
 
     pros::screen::set_pen(COLOR_WHITE);
-    pros::screen::draw_line(rx, ry, ex, ey);
+    pros::screen::draw_line(rx, ry, arrowTipX, arrowTipY);
     // Dot at robot center
     pros::screen::draw_pixel(rx, ry);
     pros::screen::draw_pixel(rx + 1, ry);
@@ -176,8 +186,8 @@ void GuiDebug::DisplayFieldMapper() {
   }
 
   // ── Data panel ────────────────────────────────────────────────────────────
-  const int dx = FM_DX;
-  int dy = FM_FY1;
+  const int dx = FIELDMAPPER_DX;
+  int dy = FIELDMAPPER_FIELDY1;
   const int rowH = 22;
 
   // Current pose values (from last map point, or zeros)
@@ -213,13 +223,13 @@ void GuiDebug::DisplayFieldMapper() {
   pros::screen::set_pen(COLOR_LIGHT_GRAY);
   pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "D:");
   pros::screen::set_pen(COLOR_GREEN);
-  snprintf(buf, sizeof(buf), "%.2f\"", mapTotalDist);
+  snprintf(buf, sizeof(buf), "%.2f\"", mapTotalDist); // cumulative path distance in inches
   pros::screen::print(pros::E_TEXT_SMALL, dx + 20, dy, buf);
   dy += rowH;
 
   // Separator
-  pros::screen::set_eraser(0x333333);
-  pros::screen::erase_rect(dx, dy, dx + FM_DW, dy + 1);
+  pros::screen::set_eraser(FIELDMAPPER_COLOR_GRID);
+  pros::screen::erase_rect(dx, dy, dx + FIELDMAPPER_DW, dy + 1);
   dy += 6;
 
   // ── Stats panel ──────────────────────────────────────────────────────────
@@ -229,46 +239,46 @@ void GuiDebug::DisplayFieldMapper() {
     dy += rowH;
 
     if (arcStartIndex >= 0 && dispEndIndex > arcStartIndex) {
-      const auto& s = mapBuffer[arcStartIndex];
-      const auto& e = mapBuffer[dispEndIndex];
-      double ddx = e.x - s.x;
-      double ddy = e.y - s.y;
-      double ddTheta = e.theta - s.theta;
-      while (ddTheta >  M_PI) ddTheta -= 2.0 * M_PI;
-      while (ddTheta < -M_PI) ddTheta += 2.0 * M_PI;
-      double hyp = std::sqrt(ddx * ddx + ddy * ddy);
+      const auto& startPose = mapBuffer[arcStartIndex];
+      const auto& endPose   = mapBuffer[dispEndIndex];
+      double deltaX     = endPose.x - startPose.x;
+      double deltaY     = endPose.y - startPose.y;
+      double deltaTheta = endPose.theta - startPose.theta;
+      while (deltaTheta >  M_PI) deltaTheta -= 2.0 * M_PI;
+      while (deltaTheta < -M_PI) deltaTheta += 2.0 * M_PI;
+      double distance = std::sqrt(deltaX * deltaX + deltaY * deltaY);
 
       pros::screen::set_pen(COLOR_LIGHT_GRAY);
       pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "X:");
       pros::screen::set_pen(COLOR_CYAN);
-      snprintf(buf, sizeof(buf), "%.2f\"", ddx);
+      snprintf(buf, sizeof(buf), "%.2f\"", deltaX);
       pros::screen::print(pros::E_TEXT_SMALL, dx + 16, dy, buf);
       pros::screen::set_pen(COLOR_LIGHT_GRAY);
       pros::screen::print(pros::E_TEXT_SMALL, dx + 130, dy, "Hdg:");
       pros::screen::set_pen(COLOR_CYAN);
-      snprintf(buf, sizeof(buf), "%.1f" "\xb0", ddTheta * (180.0 / M_PI));
+      snprintf(buf, sizeof(buf), "%.1f" "\xb0", deltaTheta * (180.0 / M_PI));
       pros::screen::print(pros::E_TEXT_SMALL, dx + 158, dy, buf);
       dy += rowH;
 
       pros::screen::set_pen(COLOR_LIGHT_GRAY);
       pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "Y:");
       pros::screen::set_pen(COLOR_CYAN);
-      snprintf(buf, sizeof(buf), "%.2f\"", ddy);
+      snprintf(buf, sizeof(buf), "%.2f\"", deltaY);
       pros::screen::print(pros::E_TEXT_SMALL, dx + 16, dy, buf);
       pros::screen::set_pen(COLOR_LIGHT_GRAY);
       pros::screen::print(pros::E_TEXT_SMALL, dx + 130, dy, "Hyp:");
       pros::screen::set_pen(COLOR_CYAN);
-      snprintf(buf, sizeof(buf), "%.2f\"", hyp);
+      snprintf(buf, sizeof(buf), "%.2f\"", distance);
       pros::screen::print(pros::E_TEXT_SMALL, dx + 158, dy, buf);
       dy += rowH;
 
       dy += rowH * 2; // padding to match row count
     } else if (arcStartIndex >= 0) {
-      pros::screen::set_pen(0x555555);
+      pros::screen::set_pen(FIELDMAPPER_COLOR_LABEL_DIM);
       pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "-- mark end --");
       dy += rowH * 3;
     } else {
-      pros::screen::set_pen(0x555555);
+      pros::screen::set_pen(FIELDMAPPER_COLOR_LABEL_DIM);
       pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "-- mark start --");
       dy += rowH * 3;
     }
@@ -298,7 +308,7 @@ void GuiDebug::DisplayFieldMapper() {
       pros::screen::set_pen(COLOR_LIGHT_GRAY);
       pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "ArcLen:");
       pros::screen::set_pen(COLOR_YELLOW);
-      snprintf(buf, sizeof(buf), "%.2f\"", arcResult.arcLength);
+      snprintf(buf, sizeof(buf), "%.2f\"", arcResult.arcLength);//Arc Length
       pros::screen::print(pros::E_TEXT_SMALL, dx + 56, dy, buf);
       if (arcResult.radius > 0.01) {
         pros::screen::set_pen(COLOR_LIGHT_GRAY);
@@ -323,13 +333,13 @@ void GuiDebug::DisplayFieldMapper() {
       }
       dy += rowH;
     } else {
-      pros::screen::set_pen(0x555555);
+      pros::screen::set_pen(FIELDMAPPER_COLOR_LABEL_DIM);
       pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "ARC: --");
       dy += rowH * 4;
     }
   } else {
     // SELECT mode — prompt
-    pros::screen::set_pen(0x888888);
+    pros::screen::set_pen(FIELDMAPPER_COLOR_LABEL_HINT);
     pros::screen::print(pros::E_TEXT_SMALL, dx, dy, "Select mode below:");
     dy += rowH * 4;
   }
@@ -337,46 +347,46 @@ void GuiDebug::DisplayFieldMapper() {
   // ── Bottom buttons ────────────────────────────────────────────────────────
   const int btnY1 = BRAIN_SCREEN_HEIGHT - 35;
   const int btnY2 = BRAIN_SCREEN_HEIGHT - 5;
-  const int halfW = (FM_DW - 6) / 2;
+  const int halfW = (FIELDMAPPER_DW - 6) / 2;
 
   if (mapMode == MapMode::SELECT) {
     // [DISPLACE]  [ARC MEAS]
-    pros::screen::set_eraser(0x005566);
+    pros::screen::set_eraser(FIELDMAPPER_COLOR_BTN_DISPLACE);
     pros::screen::erase_rect(dx, btnY1, dx + halfW, btnY2);
     pros::screen::set_pen(COLOR_WHITE);
     pros::screen::print(pros::E_TEXT_SMALL, dx + 4, btnY1 + 8, "DISPLACE");
 
-    pros::screen::set_eraser(0x005500);
-    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + FM_DW, btnY2);
+    pros::screen::set_eraser(FIELDMAPPER_COLOR_BTN_ARC_IDLE);
+    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + FIELDMAPPER_DW, btnY2);
     pros::screen::set_pen(COLOR_WHITE);
     pros::screen::print(pros::E_TEXT_SMALL, dx + halfW + 10, btnY1 + 8, "ARC MEAS");
   } else if (mapMode == MapMode::DISPLACEMENT) {
     // [MARK START]  [MARK END]
-    uint32_t startColor = (arcStartIndex >= 0) ? COLOR_DARK_GREEN : 0x005500;
+    uint32_t startColor = (arcStartIndex >= 0) ? COLOR_DARK_GREEN : FIELDMAPPER_COLOR_BTN_ARC_IDLE;
     pros::screen::set_eraser(startColor);
     pros::screen::erase_rect(dx, btnY1, dx + halfW, btnY2);
     pros::screen::set_pen(COLOR_WHITE);
     pros::screen::print(pros::E_TEXT_SMALL, dx + 4, btnY1 + 8,
                         (arcStartIndex >= 0) ? "START SET" : "MARK START");
 
-    uint32_t endColor = (dispEndIndex >= 0) ? COLOR_DARK_BLUE : 0x000055;
+    uint32_t endColor = (dispEndIndex >= 0) ? COLOR_DARK_BLUE : FIELDMAPPER_COLOR_BTN_END_IDLE;
     pros::screen::set_eraser(endColor);
-    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + FM_DW, btnY2);
+    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + FIELDMAPPER_DW, btnY2);
     pros::screen::set_pen(COLOR_WHITE);
     pros::screen::print(pros::E_TEXT_SMALL, dx + halfW + 10, btnY1 + 8,
                         (dispEndIndex >= 0) ? "END SET" : "MARK END");
   } else {
     // ARC mode — [MARK START]  [MARK END]
-    uint32_t markSColor = (arcStartIndex >= 0) ? COLOR_DARK_GREEN : 0x005500;
+    uint32_t markSColor = (arcStartIndex >= 0) ? COLOR_DARK_GREEN : FIELDMAPPER_COLOR_BTN_ARC_IDLE;
     pros::screen::set_eraser(markSColor);
     pros::screen::erase_rect(dx, btnY1, dx + halfW, btnY2);
     pros::screen::set_pen(COLOR_WHITE);
     pros::screen::print(pros::E_TEXT_SMALL, dx + 4, btnY1 + 8,
                         (arcStartIndex >= 0) ? "START SET" : "MARK START");
 
-    uint32_t markEColor = arcMeasured ? COLOR_DARK_BLUE : 0x000055;
+    uint32_t markEColor = arcMeasured ? COLOR_DARK_BLUE : FIELDMAPPER_COLOR_BTN_END_IDLE;
     pros::screen::set_eraser(markEColor);
-    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + FM_DW, btnY2);
+    pros::screen::erase_rect(dx + halfW + 6, btnY1, dx + FIELDMAPPER_DW, btnY2);
     pros::screen::set_pen(COLOR_WHITE);
     pros::screen::print(pros::E_TEXT_SMALL, dx + halfW + 10, btnY1 + 8, "MARK END");
   }
@@ -420,12 +430,12 @@ void GuiDebug::HandleFieldMapperTouch() {
   {
     const int btnY1 = BRAIN_SCREEN_HEIGHT - 35;
     const int btnY2 = BRAIN_SCREEN_HEIGHT - 5;
-    const int halfW = (FM_DW - 6) / 2;
-    const int markSX2 = FM_DX + halfW;
-    const int markEX1 = FM_DX + halfW + 6;
-    const int markEX2 = FM_DX + FM_DW;
+    const int halfW = (FIELDMAPPER_DW - 6) / 2;
+    const int startBtnX2 = FIELDMAPPER_DX + halfW;          // right edge of start button
+    const int endBtnX1   = FIELDMAPPER_DX + halfW + 6;       // left edge of end button
+    const int endBtnX2   = FIELDMAPPER_DX + FIELDMAPPER_DW;  // right edge of end button
 
-    if (x >= FM_DX && x <= markSX2 && y >= btnY1 && y <= btnY2) {
+    if (x >= FIELDMAPPER_DX && x <= startBtnX2 && y >= btnY1 && y <= btnY2) {
       if (mapMode == MapMode::SELECT) {
         // Enter DISPLACEMENT mode
         mapMode = MapMode::DISPLACEMENT;
@@ -446,7 +456,7 @@ void GuiDebug::HandleFieldMapperTouch() {
       return;
     }
 
-    if (x >= markEX1 && x <= markEX2 && y >= btnY1 && y <= btnY2) {
+    if (x >= endBtnX1 && x <= endBtnX2 && y >= btnY1 && y <= btnY2) {
       if (mapMode == MapMode::SELECT) {
         // Enter ARC mode
         mapMode = MapMode::ARC;

--- a/src/aon/tools/gui/gui-debug.cpp
+++ b/src/aon/tools/gui/gui-debug.cpp
@@ -112,8 +112,10 @@ void GuiDebug::ClearMapPath() {
   mapBufferCount = 0;
   mapTotalDist   = 0.0;
   arcStartIndex  = -1;
+  dispEndIndex   = -1;
   arcMeasured    = false;
   arcResult      = {};
+  mapMode        = MapMode::SELECT;
 }
 
 // ============================================================================

--- a/src/aon/tools/gui/gui-debug.cpp
+++ b/src/aon/tools/gui/gui-debug.cpp
@@ -236,26 +236,17 @@ void GuiDebug::HandleDebugMenuTouch() {
     const int startX = 20, startY = 65;
     const int btnWidth = (BRAIN_SCREEN_WIDTH - 2 * startX - (cols - 1) * gap) / cols;
     const int btnHeight = (BRAIN_SCREEN_HEIGHT - startY - startX - (rows - 1) * gap) / rows;
-    struct BtnPos { int col, row; };
-    BtnPos buttons[] = {
-      {0, 0}, // Registered Autons
-      {1, 0}, // Live Graph
-      {2, 0}, // Variables
-      {0, 1}, // Auton Runner
-      {1, 1}, // Data
-      {2, 1}, // Field Map
-    };
-    
-    for (int i = 0; i < 6; ++i) {
-      int btnX = startX + buttons[i].col * (btnWidth + gap);
-      int btnY = startY + buttons[i].row * (btnHeight + gap);
+
+    for (int i = 0; i < cols * rows; ++i) {
+      int btnX = startX + (i % cols) * (btnWidth + gap);
+      int btnY = startY + (i / cols) * (btnHeight + gap);
       
       if (x >= btnX && x <= btnX + btnWidth && y >= btnY && y <= btnY + btnHeight) {
         switch (i) {
           case 0: DisplayRegisteredAutonsMenu(); currentScreen = RegisteredFunctions; break;
           case 1: DisplayLiveGraph(); currentScreen = LiveGraph; break;
-          case 2: DisplayAutonRunner(); currentScreen = AutonRunner; break;
-          case 3: previousScreen = DebugMenu; DisplayVariablesMenu(); currentScreen = VARS; break;
+          case 2: previousScreen = DebugMenu; DisplayVariablesMenu(); currentScreen = VARS; break;
+          case 3: DisplayAutonRunner(); currentScreen = AutonRunner; break;
           case 4: DisplayDataMenu(); currentScreen = DATA; break;
           case 5: DisplayFieldMapper(); currentScreen = FieldMapper; break;
         }

--- a/src/aon/tools/gui/gui-debug.cpp
+++ b/src/aon/tools/gui/gui-debug.cpp
@@ -90,6 +90,33 @@ void GuiDebug::AddGraphPoint(double x, double y) {
 }
 
 // ============================================================================
+// Field Mapper Methods
+// ============================================================================
+
+void GuiDebug::setMapDataProvider(std::function<Pose()> getPose) {
+  mapGetPose = std::move(getPose);
+}
+
+void GuiDebug::AddMapPoint(double x, double y, double theta) {
+  if (mapBufferCount >= MAP_BUFFER_SIZE) return;
+  if (mapBufferCount > 0) {
+    const auto& prev = mapBuffer[mapBufferCount - 1];
+    double dx = x - prev.x;
+    double dy = y - prev.y;
+    mapTotalDist += std::sqrt(dx * dx + dy * dy);
+  }
+  mapBuffer[mapBufferCount++] = {x, y, theta};
+}
+
+void GuiDebug::ClearMapPath() {
+  mapBufferCount = 0;
+  mapTotalDist   = 0.0;
+  arcStartIndex  = -1;
+  arcMeasured    = false;
+  arcResult      = {};
+}
+
+// ============================================================================
 // Debug Display Methods (Delegated to Subsystems)
 // ============================================================================
 
@@ -122,10 +149,11 @@ void GuiDebug::DisplayDebugMenu() {
     {"Live", "Graph", 1, 0},
     {"Variables", "", 2, 0},
     {"Auton", "Runner", 0, 1},
-    {"Data", "", 1, 1}
+    {"Data", "", 1, 1},
+    {"Field", "Map", 2, 1},
   };
   
-  for (int i = 0; i < 5; ++i) {
+  for (int i = 0; i < 6; ++i) {
     int x = startX + buttons[i].col * (btnWidth + gap);
     int y = startY + buttons[i].row * (btnHeight + gap);
     
@@ -208,10 +236,11 @@ void GuiDebug::HandleDebugMenuTouch() {
       {1, 0, 1}, // Live Graph
       {2, 0, 3}, // Variables
       {0, 1, 2}, // Auton Runner
-      {1, 1, 4}  // Odometry
+      {1, 1, 4}, // Data
+      {2, 1, 5}, // Field Map
     };
     
-    for (int i = 0; i < 5; ++i) {
+    for (int i = 0; i < 6; ++i) {
       int btnX = startX + buttons[i].col * (btnWidth + gap);
       int btnY = startY + buttons[i].row * (btnHeight + gap);
       
@@ -222,6 +251,7 @@ void GuiDebug::HandleDebugMenuTouch() {
           case 2: DisplayAutonRunner(); currentScreen = AutonRunner; break;
           case 3: previousScreen = DebugMenu; DisplayVariablesMenu(); currentScreen = VARS; break;
           case 4: DisplayDataMenu(); currentScreen = DATA; break;
+          case 5: DisplayFieldMapper(); currentScreen = FieldMapper; break;
         }
         pros::delay(400);
         return;
@@ -277,6 +307,9 @@ void GuiDebug::mainLoop() {
         case LiveGraph:
           HandleLiveGraphTouch();
           break;
+        case FieldMapper:
+          HandleFieldMapperTouch();
+          break;
         default:
           break;
       }
@@ -311,6 +344,12 @@ void GuiDebug::mainLoop() {
         if (graphGetX && graphGetY) {
           AddGraphPoint(graphGetX(), graphGetY());
         }
+      } else if (currentScreen == FieldMapper) {
+        if (mapGetPose) {
+          Pose p = mapGetPose();
+          AddMapPoint(p.x, p.y, p.theta);
+        }
+        DisplayFieldMapper();
       }
       refreshCounter = 0;
     }

--- a/src/aon/tools/gui/gui-debug.cpp
+++ b/src/aon/tools/gui/gui-debug.cpp
@@ -137,8 +137,10 @@ void GuiDebug::DisplayDebugMenu() {
   pros::screen::print(pros::E_TEXT_MEDIUM, 20, 18, "BACK");
 
   // Buttons for debug options
-  int btnWidth = 100, btnHeight = 55, gap = 10;
-  int startX = 20, startY = 65;
+  const int cols = 3, rows = 2, gap = 10;
+  const int startX = 20, startY = 65;
+  const int btnWidth = (BRAIN_SCREEN_WIDTH - 2 * startX - (cols - 1) * gap) / cols;
+  const int btnHeight = (BRAIN_SCREEN_HEIGHT - startY - startX - (rows - 1) * gap) / rows;
   
   struct BtnInfo {
     const char* text1;
@@ -230,8 +232,10 @@ void GuiDebug::HandleDebugMenuTouch() {
       return;
     }
 
-    int btnWidth = 100, btnHeight = 55, gap = 10;
-    int startX = 20, startY = 65;
+    const int cols = 3, rows = 2, gap = 10;
+    const int startX = 20, startY = 65;
+    const int btnWidth = (BRAIN_SCREEN_WIDTH - 2 * startX - (cols - 1) * gap) / cols;
+    const int btnHeight = (BRAIN_SCREEN_HEIGHT - startY - startX - (rows - 1) * gap) / rows;
     struct BtnPos { int col, row; };
     BtnPos buttons[] = {
       {0, 0}, // Registered Autons

--- a/src/aon/tools/gui/gui-debug.cpp
+++ b/src/aon/tools/gui/gui-debug.cpp
@@ -232,14 +232,14 @@ void GuiDebug::HandleDebugMenuTouch() {
 
     int btnWidth = 100, btnHeight = 55, gap = 10;
     int startX = 20, startY = 65;
-    struct BtnPos { int col, row, index; };
+    struct BtnPos { int col, row; };
     BtnPos buttons[] = {
-      {0, 0, 0}, // Registered Autons
-      {1, 0, 1}, // Live Graph
-      {2, 0, 3}, // Variables
-      {0, 1, 2}, // Auton Runner
-      {1, 1, 4}, // Data
-      {2, 1, 5}, // Field Map
+      {0, 0}, // Registered Autons
+      {1, 0}, // Live Graph
+      {2, 0}, // Variables
+      {0, 1}, // Auton Runner
+      {1, 1}, // Data
+      {2, 1}, // Field Map
     };
     
     for (int i = 0; i < 6; ++i) {
@@ -247,7 +247,7 @@ void GuiDebug::HandleDebugMenuTouch() {
       int btnY = startY + buttons[i].row * (btnHeight + gap);
       
       if (x >= btnX && x <= btnX + btnWidth && y >= btnY && y <= btnY + btnHeight) {
-        switch (buttons[i].index) {
+        switch (i) {
           case 0: DisplayRegisteredAutonsMenu(); currentScreen = RegisteredFunctions; break;
           case 1: DisplayLiveGraph(); currentScreen = LiveGraph; break;
           case 2: DisplayAutonRunner(); currentScreen = AutonRunner; break;


### PR DESCRIPTION
Summary
This PR adds a Field Mapper tool to the debug GUI and extends existing GUI functionality with a RESET button for the Auton Runner and a resetPose method on the Drivetrain class.

Changes
New: Field Mapper (fieldmapper.cpp, gui-debug.hpp)
Added a new FieldMapper debug tool to the GUI that allows path tracing and arc measurement directly on a field view
Enables visual mapping of robot paths and autonomous routes during development and testing
Auton Runner Improvements (autonrunner.cpp)
Added a RESET button to the Auton Runner GUI panel, allowing the autonomous routine state to be reset without restarting the program
Drivetrain (drivetrain.hpp)
Added resetPose() method to the Drivetrain class to reset odometry to a known state, supporting use cases like re-zeroing mid-match or before an auto routine
Documentation (GUIDE_GUI.md)
Updated the GUI guide with documentation for the new Field Mapper tool and updated usage instructions
