### PR TITLE
Auton Button Title Fix (Requested)

### DIFF
--- a/include/aon/tools/gui/gui.hpp
+++ b/include/aon/tools/gui/gui.hpp
@@ -60,6 +60,7 @@ enum GuiScreen {
 struct AutonOption {
   const char* name;
   int (*routine)();
+  const char* buttonLabel = nullptr;
 };
 
 // Constants
@@ -86,24 +87,24 @@ public:
   GuiScreen currentScreen = MainMenu;
   GuiScreen previousScreen = MainMenu;
 
-  // TODO: move this to be only parameter based
   // Auton routines for each alliance
+  //3rd option is for button label keep it to less than 4 characters
   AutonOption redAutonOptions[autonOptionsCount] = {
-    {"Black Beard", aon::routines::RedRoutine1},
-    {"Jack Sparrow", aon::routines::RedRoutine2},
-    {"Red AUT3", aon::routines::RedRoutine3},
+    {"Black Beard", aon::routines::RedRoutine1, "BB"},
+    {"Jack Sparrow", aon::routines::RedRoutine2, "JKS"},
+    {"Red AUT3", aon::routines::RedRoutine3, "R3"},
   };
   
   AutonOption blueAutonOptions[autonOptionsCount] = {
-    {"Black Beard", aon::routines::BlueRoutine1},
-    {"Jack Sparrow", aon::routines::BlueRoutine2},
-    {"Blue AUT3", aon::routines::BlueRoutine3},
+    {"Black Beard", aon::routines::BlueRoutine1, "BB"},
+    {"Jack Sparrow", aon::routines::BlueRoutine2, "JKS"},
+    {"Blue AUT3", aon::routines::BlueRoutine3, "B3"},
   };
   
   AutonOption skillsAutonOptions[autonOptionsCount] = {
-    {"Skills AUT1", aon::routines::SkillsRoutine1},
-    {"Skills AUT2", aon::routines::SkillsRoutine2},
-    {"Skills AUT3", aon::routines::SkillsRoutine3},
+    {"Skills AUT1", aon::routines::SkillsRoutine1, "S1"},
+    {"Skills AUT2", aon::routines::SkillsRoutine2, "S2"},
+    {"Skills AUT3", aon::routines::SkillsRoutine3, "S3"},
   };
 
 

--- a/src/aon/tools/gui/gui-debug.cpp
+++ b/src/aon/tools/gui/gui-debug.cpp
@@ -1,4 +1,4 @@
-#include "../../../include/aon/tools/gui/gui-debug.hpp"
+#include "../../../../include/aon/tools/gui/gui-debug.hpp"
 namespace aon {
 
 // ============================================================================

--- a/src/aon/tools/gui/gui.cpp
+++ b/src/aon/tools/gui/gui.cpp
@@ -1,7 +1,7 @@
-#include "../../../include/aon/tools/gui/gui.hpp"
-#include "../../../include/aon/tools/gui/gui-debug.hpp"
-#include "../../../include/aon/constants.hpp"
-#include "../../../include/aon/tools/gui/ui/gui-layout.hpp"
+#include "../../../../include/aon/tools/gui/gui.hpp"
+#include "../../../../include/aon/tools/gui/gui-debug.hpp"
+#include "../../../../include/aon/constants.hpp"
+#include "../../../../include/aon/tools/gui/ui/gui-layout.hpp"
 
 namespace aon {
 

--- a/src/aon/tools/gui/ui/gui-displays.cpp
+++ b/src/aon/tools/gui/ui/gui-displays.cpp
@@ -71,9 +71,9 @@ void Gui::displayRedAutonMenu() {
   pros::screen::print(pros::E_TEXT_LARGE_CENTER, 4, "RED");
 
   // Draw auton selection buttons with red theme colors
-  ui::Button aut1 = aut1Btn; aut1.bg = COLOR_LIGHT_PINK;
-  ui::Button aut2 = Aut2Btn; aut2.bg = COLOR_CRIMSON;
-  ui::Button aut3 = Aut3Btn; aut3.bg = COLOR_RED;
+  ui::Button aut1 = aut1Btn; aut1.bg = COLOR_LIGHT_PINK; aut1.label = redAutonOptions[0].buttonLabel;
+  ui::Button aut2 = Aut2Btn; aut2.bg = COLOR_CRIMSON; aut2.label = redAutonOptions[1].buttonLabel;
+  ui::Button aut3 = Aut3Btn; aut3.bg = COLOR_RED; aut3.label = redAutonOptions[2].buttonLabel;
   aut1.draw(pros::E_TEXT_LARGE);
   aut2.draw(pros::E_TEXT_LARGE);
   aut3.draw(pros::E_TEXT_LARGE);
@@ -103,9 +103,9 @@ void Gui::displayBlueAutonMenu() {
   pros::screen::print(pros::E_TEXT_LARGE_CENTER, 4, "BLUE");
 
   // Draw auton selection buttons with blue theme colors
-  ui::Button aut1 = aut1Btn; aut1.bg = COLOR_SKY_BLUE;
-  ui::Button aut2 = Aut2Btn; aut2.bg = COLOR_STEEL_BLUE;
-  ui::Button aut3 = Aut3Btn; aut3.bg = COLOR_BLUE;
+  ui::Button aut1 = aut1Btn; aut1.bg = COLOR_SKY_BLUE; aut1.label = blueAutonOptions[0].buttonLabel;
+  ui::Button aut2 = Aut2Btn; aut2.bg = COLOR_STEEL_BLUE; aut2.label = blueAutonOptions[1].buttonLabel;
+  ui::Button aut3 = Aut3Btn; aut3.bg = COLOR_BLUE; aut3.label = blueAutonOptions[2].buttonLabel;
   aut1.draw(pros::E_TEXT_LARGE);
   aut2.draw(pros::E_TEXT_LARGE);
   aut3.draw(pros::E_TEXT_LARGE);
@@ -138,9 +138,9 @@ void Gui::displaySkillsMenu() {
   pros::screen::print(pros::E_TEXT_LARGE_CENTER, 4, "SKILLS");
 
   // Draw auton selection buttons with green theme colors
-  ui::Button aut1 = aut1Btn; aut1.bg = COLOR_LIGHT_GREEN;
-  ui::Button aut2 = Aut2Btn; aut2.bg = COLOR_YELLOW_GREEN;
-  ui::Button aut3 = Aut3Btn; aut3.bg = COLOR_GREEN;
+  ui::Button aut1 = aut1Btn; aut1.bg = COLOR_LIGHT_GREEN; aut1.label = skillsAutonOptions[0].buttonLabel;
+  ui::Button aut2 = Aut2Btn; aut2.bg = COLOR_YELLOW_GREEN; aut2.label = skillsAutonOptions[1].buttonLabel;
+  ui::Button aut3 = Aut3Btn; aut3.bg = COLOR_GREEN; aut3.label = skillsAutonOptions[2].buttonLabel;
   aut1.draw(pros::E_TEXT_LARGE);
   aut2.draw(pros::E_TEXT_LARGE);
   aut3.draw(pros::E_TEXT_LARGE);

--- a/src/aon/tools/gui/ui/gui-displays.cpp
+++ b/src/aon/tools/gui/ui/gui-displays.cpp
@@ -1,7 +1,7 @@
-#include "../../../include/aon/tools/gui/gui.hpp"
-#include "../../../include/aon/tools/gui/gui-debug.hpp"
-#include "../../../include/aon/constants.hpp"
-#include "../../../include/aon/tools/gui/ui/gui-layout.hpp"
+#include "../../../../../include/aon/tools/gui/gui.hpp"
+#include "../../../../../include/aon/tools/gui/gui-debug.hpp"
+#include "../../../../../include/aon/constants.hpp"
+#include "../../../../../include/aon/tools/gui/ui/gui-layout.hpp"
 
 namespace aon {
 


### PR DESCRIPTION
In this commit, I changed the hard-coded logic for the selection buttons found in the Blue, Red, and Skills selection screens.
This aims to facilitate the intuitiveness of the auton selection screen and the ease of use for the programmer to name them.

P.S. It includes an include fix that popped up during development.